### PR TITLE
feat: concat strings

### DIFF
--- a/codegen/jasm.go
+++ b/codegen/jasm.go
@@ -42,6 +42,16 @@ func (j *JASM) FinishMain() {
 	j.addLine("}")
 }
 
+func (j *JASM) StartInvokeDynamic(param string) {
+	j.addLine(fmt.Sprintf("invokedynamic %s {", param))
+	j.incTab()
+}
+
+func (j *JASM) FinishInvokeDynamic() {
+	j.decTab()
+	j.addLine("}")
+}
+
 func (j *JASM) Code() string {
 	return strings.Join(j.code, "")
 }

--- a/codegen/tree_shape_listener.go
+++ b/codegen/tree_shape_listener.go
@@ -62,6 +62,18 @@ func (t *TreeShapeListener) ExitBlock(ctx *parsing.BlockContext) {
 	t.procedureDefinitionName = ""
 }
 
+func (t *TreeShapeListener) ExitSimpleExpression(ctx *parsing.SimpleExpressionContext) {
+	if ctx.GetT2() != nil {
+		if ctx.GetOp() == ctx.Additiveoperator() {
+			// Only works for string types.
+			t.jasm.StartInvokeDynamic(`makeConcatWithConstants(java/lang/String, java/lang/String)java/lang/String`)
+			t.jasm.AddOpcode(`invokestatic java/lang/invoke/StringConcatFactory.makeConcatWithConstants(java/lang/invoke/MethodHandles$Lookup, java/lang/String, java/lang/invoke/MethodType, java/lang/String, [java/lang/Object)java/lang/invoke/CallSite`)
+			t.jasm.AddOpcode(`[""]`)
+			t.jasm.FinishInvokeDynamic()
+		}
+	}
+}
+
 func (t *TreeShapeListener) Code() string {
 	return t.jasm.Code()
 }

--- a/examples/concat_strings.pas
+++ b/examples/concat_strings.pas
@@ -1,0 +1,5 @@
+program ConcatStrings;
+begin
+  writeln ('Hello ' + 'world!');
+end.
+

--- a/parser/Pascal.g4
+++ b/parser/Pascal.g4
@@ -308,7 +308,7 @@ relationaloperator
     ;
 
 simpleExpression
-    : term (additiveoperator simpleExpression)?
+    : t1 = term (op = additiveoperator t2 = simpleExpression)?
     ;
 
 additiveoperator


### PR DESCRIPTION
It only works with string types.

Bellow there is an example in Pascal:

```
program ConcatStrings;
begin
  writeln ('Hello ' + 'world!');
end.
```

To execute:

`./bin/poj ./examples/concat_strings && jasm ./concat_strings.jasm && java concat_strings`