### PR TITLE
Fix mixed types in writeln

### DIFF
--- a/codegen/tree_shape_listener.go
+++ b/codegen/tree_shape_listener.go
@@ -29,9 +29,11 @@ func (t *TreeShapeListener) ExitProgram(ctx *parsing.ProgramContext) {
 }
 
 func (t *TreeShapeListener) EnterProcedureStatement(ctx *parsing.ProcedureStatementContext) {
-	if ctx.GetProcedureID().GetText() == "writeln" {
-		t.jasm.AddOpcode("getstatic", "java/lang/System.out", "java/io/PrintStream")
-	}
+	t.procedureDefinitionName = ctx.GetProcedureID().GetText()
+}
+
+func (t *TreeShapeListener) ExitProcedureStatement(ctx *parsing.ProcedureStatementContext) {
+	t.procedureDefinitionName = ""
 }
 
 func (t *TreeShapeListener) ExitString(ctx *parsing.StringContext) {
@@ -40,8 +42,14 @@ func (t *TreeShapeListener) ExitString(ctx *parsing.StringContext) {
 	t.pst.Push(String)
 }
 
-func (t *TreeShapeListener) ExitProcedureStatement(ctx *parsing.ProcedureStatementContext) {
-	if ctx.GetProcedureID().GetText() == "writeln" {
+func (t *TreeShapeListener) EnterActualParameter(ctx *parsing.ActualParameterContext) {
+	if t.procedureDefinitionName == "writeln" {
+		t.jasm.AddOpcode("getstatic", "java/lang/System.out", "java/io/PrintStream")
+	}
+}
+
+func (t *TreeShapeListener) ExitActualParameter(ctx *parsing.ActualParameterContext) {
+	if t.procedureDefinitionName == "writeln" {
 		pt := t.pst.Pop()
 		if pt == String {
 			t.jasm.AddOpcode("invokevirtual", "java/io/PrintStream.println(java/lang/String)V")

--- a/java_samples/TwoTypesInPrintln.cleaned.jasm
+++ b/java_samples/TwoTypesInPrintln.cleaned.jasm
@@ -1,0 +1,34 @@
+/*
+ * Disassembled from TwoTypesInPrintln.class (originally TwoTypesInPrintln.java) by JASM
+ *
+ * Original class version: 55
+ * Signature: <no signature>
+ */
+public class TwoTypesInPrintln {
+    // <no signature>
+    // <no exceptions>
+    public <init>()V {
+        
+        label0:
+        aload 0
+        invokespecial java/lang/Object.<init>()V
+        return
+    }
+
+
+    // <no signature>
+    // <no exceptions>
+    public static main([java/lang/String)V {
+        
+        getstatic java/lang/System.out java/io/PrintStream
+        ldc "Hello"
+        invokevirtual java/io/PrintStream.println(java/lang/String)V
+        
+        getstatic java/lang/System.out java/io/PrintStream
+        bipush 123
+        invokevirtual java/io/PrintStream.println(I)V
+        
+        return
+    }
+
+}

--- a/java_samples/TwoTypesInPrintln.jasm
+++ b/java_samples/TwoTypesInPrintln.jasm
@@ -1,0 +1,37 @@
+/*
+ * Disassembled from TwoTypesInPrintln.class (originally TwoTypesInPrintln.java) by JASM
+ *
+ * Original class version: 55
+ * Signature: <no signature>
+ */
+public class TwoTypesInPrintln {
+    // <no signature>
+    // <no exceptions>
+    public <init>()V {
+        
+        label0:
+        aload 0
+        invokespecial java/lang/Object.<init>()V
+        return
+    }
+
+
+    // <no signature>
+    // <no exceptions>
+    public static main([java/lang/String)V {
+        
+        label0:
+        getstatic java/lang/System.out java/io/PrintStream
+        ldc "Hello"
+        invokevirtual java/io/PrintStream.println(java/lang/String)V
+        
+        label1:
+        getstatic java/lang/System.out java/io/PrintStream
+        bipush 123
+        invokevirtual java/io/PrintStream.println(I)V
+        
+        label2:
+        return
+    }
+
+}

--- a/java_samples/TwoTypesInPrintln.java
+++ b/java_samples/TwoTypesInPrintln.java
@@ -1,0 +1,6 @@
+public class TwoTypesInPrintln {
+   public static void main(String[] args) {
+      System.out.println("Hello");
+      System.out.println(123);
+   }
+}

--- a/tests/pascal_programs/hello_world_two_types.pas
+++ b/tests/pascal_programs/hello_world_two_types.pas
@@ -1,0 +1,4 @@
+program Hello;
+begin
+  writeln ('Hello ', 12345);
+end.


### PR DESCRIPTION
This pull request primarily modifies the `TreeShapeListener` object in the `codegen/tree_shape_listener.go` file to fix the handling of procedure statements and actual parameters. It also includes new sample files for Java and Pascal programs.

Changes to `TreeShapeListener`:

* [`codegen/tree_shape_listener.go`](diffhunk://#diff-2c6f4e667e08fa28b1ce914308e7882e44ae44b7d89fc0c3688430a1b6439146L32-R36): The `EnterProcedureStatement` method now sets `t.procedureDefinitionName` to the text of the current procedure ID. The `ExitProcedureStatement` method resets `t.procedureDefinitionName` to an empty string. Previously, these methods contained a hardcoded check for the "writeln" procedure. This change makes the code more flexible and maintainable.
* [`codegen/tree_shape_listener.go`](diffhunk://#diff-2c6f4e667e08fa28b1ce914308e7882e44ae44b7d89fc0c3688430a1b6439146L43-R52): The `ExitProcedureStatement` method has been replaced with `EnterActualParameter` and `ExitActualParameter` methods. These methods handle the "writeln" procedure in a more appropriate context, maintaining the functionality of the previous implementation.

Addition of sample files:

* `java_samples/TwoTypesInPrintln.cleaned.jasm`, `java_samples/TwoTypesInPrintln.jasm`, and `java_samples/TwoTypesInPrintln.java`: These new files contain a simple Java program that prints a string and an integer to the console. They serve as examples of the output of the code generation process. [[1]](diffhunk://#diff-509da14efd618e888ef246db87ca8e3636e734cdde78b3793cf708b848d50865R1-R34) [[2]](diffhunk://#diff-9543648201b3d8cb2acc133de49170c9dbe79a4e2e1b174a04eae6b300f8589fR1-R37) [[3]](diffhunk://#diff-fa6f88b6a375b72cec110f829995a38f6cdb3065af865efc49de524e7a7991d2R1-R6)
* [`tests/pascal_programs/hello_world_two_types.pas`](diffhunk://#diff-10910a5ef91259f63478c61431f0d23c589767fe3a6be487662f8b26df3bff6eR1-R4): This new file contains a simple Pascal program that writes a string and an integer to the console. It serves as an example of the input to the code generation process.