### PR TITLE
Refactors jasm and parser

### DIFF
--- a/codegen/code.go
+++ b/codegen/code.go
@@ -1,0 +1,35 @@
+package codegen
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Code struct {
+	code []string
+	tabs string
+}
+
+func NewCode() *Code {
+	return &Code{}
+}
+
+func (c *Code) IncTab() {
+	c.tabs += "\t"
+}
+
+func (c *Code) DecTab() {
+	if len(c.tabs) == 0 {
+		return
+	}
+
+	c.tabs = c.tabs[:len(c.tabs)-1]
+}
+
+func (c *Code) AddLine(line string) {
+	c.code = append(c.code, fmt.Sprintf("%s%s\n", c.tabs, line))
+}
+
+func (c *Code) Code() string {
+	return strings.Join(c.code, "")
+}

--- a/codegen/jasm.go
+++ b/codegen/jasm.go
@@ -6,8 +6,7 @@ import (
 )
 
 type JASM struct {
-	code       []string
-	tabs       string
+	code       *Code
 	labelID    int
 	pst        *StackType
 	endIfLabel string
@@ -16,7 +15,8 @@ type JASM struct {
 
 func NewJASM() *JASM {
 	return &JASM{
-		pst: NewStackType(),
+		code: NewCode(),
+		pst:  NewStackType(),
 	}
 }
 
@@ -94,6 +94,13 @@ func (j *JASM) AddOperatorOpcode(op string) {
 	}
 
 	switch {
+	case op == "and":
+		switch pt1 {
+		case Boolean:
+			j.genMulIntegers()
+		default:
+			j.AddOpcode("invalid type in mul")
+		}
 	case op == "*":
 		switch pt1 {
 		case Integer:
@@ -201,23 +208,19 @@ func (j *JASM) newLabel() string {
 }
 
 func (j *JASM) Code() string {
-	return strings.Join(j.code, "")
+	return j.code.Code()
 }
 
 func (j *JASM) addLine(line string) {
-	j.code = append(j.code, fmt.Sprintf("%s%s\n", j.tabs, line))
+	j.code.AddLine(line)
 }
 
 func (j *JASM) incTab() {
-	j.tabs += "\t"
+	j.code.IncTab()
 }
 
 func (j *JASM) decTab() {
-	if len(j.tabs) == 0 {
-		return
-	}
-
-	j.tabs = j.tabs[:len(j.tabs)-1]
+	j.code.DecTab()
 }
 
 func (j *JASM) genAddStrings() {

--- a/codegen/tree_shape_listener.go
+++ b/codegen/tree_shape_listener.go
@@ -9,16 +9,12 @@ type TreeShapeListener struct {
 	filename                string
 	jasm                    *JASM
 	procedureDefinitionName string
-	pst                     *StackType
-	endIfLabel              string
-	elseLabel               string
 }
 
 func NewTreeShapeListener(filename string) *TreeShapeListener {
 	return &TreeShapeListener{
 		filename: filename,
 		jasm:     NewJASM(),
-		pst:      NewStackType(),
 	}
 }
 
@@ -36,34 +32,26 @@ func (t *TreeShapeListener) EnterProcedureStatement(ctx *parsing.ProcedureStatem
 
 func (t *TreeShapeListener) ExitProcedureStatement(ctx *parsing.ProcedureStatementContext) {
 	if t.procedureDefinitionName == "writeln" {
-		t.jasm.AddOpcode("getstatic", "java/lang/System.out", "java/io/PrintStream")
-		t.jasm.AddOpcode("invokevirtual", "java/io/PrintStream.println()V")
+		t.jasm.AddStaticPrintStream()
+		t.jasm.AddInvokeVirtualPrintln()
 	}
 	t.procedureDefinitionName = ""
 }
 
 func (t *TreeShapeListener) ExitString(ctx *parsing.StringContext) {
 	str := ctx.GetText()
-	t.jasm.AddOpcode("ldc", "\""+str+"\"")
-	t.pst.Push(String)
+	t.jasm.AddLdcStringOpcode("\"" + str + "\"")
 }
 
 func (t *TreeShapeListener) EnterActualParameter(ctx *parsing.ActualParameterContext) {
 	if t.procedureDefinitionName == "write" || t.procedureDefinitionName == "writeln" {
-		t.jasm.AddOpcode("getstatic", "java/lang/System.out", "java/io/PrintStream")
+		t.jasm.AddStaticPrintStream()
 	}
 }
 
 func (t *TreeShapeListener) ExitActualParameter(ctx *parsing.ActualParameterContext) {
 	if t.procedureDefinitionName == "write" || t.procedureDefinitionName == "writeln" {
-		pt := t.pst.Pop()
-		if pt == String {
-			t.jasm.AddOpcode("invokevirtual", "java/io/PrintStream.print(java/lang/String)V")
-		} else if pt == Integer {
-			t.jasm.AddOpcode("invokevirtual", "java/io/PrintStream.print(I)V")
-		} else {
-			t.jasm.AddOpcode("undefined type in write/writeln")
-		}
+		t.jasm.AddInvokeVirtualPrintWithType()
 	}
 }
 
@@ -88,167 +76,34 @@ func (t *TreeShapeListener) ExitBlock(ctx *parsing.BlockContext) {
 }
 
 func (t *TreeShapeListener) ExitMulDivOp(ctx *parsing.MulDivOpContext) {
-	pt1 := t.pst.Pop()
-	pt2 := t.pst.Pop()
-	if pt1 != pt2 {
-		t.jasm.AddOpcode("invalid types")
-		return
-	}
-
 	op := ctx.GetOp().GetText()
-	switch {
-	case op == "*":
-		switch pt1 {
-		case Integer:
-			t.GenMulIntegers()
-		default:
-			t.jasm.AddOpcode("invalid type in mul")
-		}
-	case op == "/":
-		switch pt1 {
-		case Integer:
-			t.GenDivIntegers()
-		default:
-			t.jasm.AddOpcode("invalid type in div")
-		}
-	}
+	t.jasm.AddOperatorOpcode(op)
 }
 
 func (t *TreeShapeListener) ExitAddOp(ctx *parsing.AddOpContext) {
-	pt1 := t.pst.Pop()
-	pt2 := t.pst.Pop()
-	if pt1 != pt2 {
-		t.jasm.AddOpcode("invalid types")
-		return
-	}
-
 	op := ctx.GetOp().GetText()
-	switch {
-	case op == "+":
-		switch pt1 {
-		case String:
-			t.GenAddStrings()
-		case Integer:
-			t.GenAddIntegers()
-		default:
-			t.jasm.AddOpcode("invalid type in add")
-		}
-	case op == "-":
-		switch pt1 {
-		case Integer:
-			t.GenSubIntegers()
-		default:
-			t.jasm.AddOpcode("invalid type in sub")
-		}
-	}
-}
-
-func (t *TreeShapeListener) GenAddStrings() {
-	t.jasm.StartInvokeDynamic(`makeConcatWithConstants(java/lang/String, java/lang/String)java/lang/String`)
-	t.jasm.AddOpcode(`invokestatic java/lang/invoke/StringConcatFactory.makeConcatWithConstants(java/lang/invoke/MethodHandles$Lookup, java/lang/String, java/lang/invoke/MethodType, java/lang/String, [java/lang/Object)java/lang/invoke/CallSite`)
-	t.jasm.AddOpcode(`[""]`)
-	t.jasm.FinishInvokeDynamic()
-	t.pst.Push(String)
-}
-
-func (t *TreeShapeListener) GenAddIntegers() {
-	t.jasm.AddOpcode("iadd")
-	t.pst.Push(Integer)
-}
-
-func (t *TreeShapeListener) GenSubIntegers() {
-	t.jasm.AddOpcode("isub")
-	t.pst.Push(Integer)
-}
-
-func (t *TreeShapeListener) GenMulIntegers() {
-	t.jasm.AddOpcode("imul")
-	t.pst.Push(Integer)
-}
-
-func (t *TreeShapeListener) GenDivIntegers() {
-	t.jasm.AddOpcode("idiv")
-	t.pst.Push(Integer)
+	t.jasm.AddOperatorOpcode(op)
 }
 
 func (t *TreeShapeListener) ExitRelOp(ctx *parsing.RelOpContext) {
-	pt1 := t.pst.Pop()
-	pt2 := t.pst.Pop()
-	if pt1 != pt2 {
-		t.jasm.AddOpcode("invalid types")
-		return
-	}
-
 	op := ctx.GetOp().GetText()
-	switch {
-	case op == ">":
-		switch pt1 {
-		case Integer:
-			t.jasm.AddOpcode("if_icmple", t.elseLabel)
-			t.pst.Push(Integer)
-		default:
-			t.jasm.AddOpcode("invalid type in comparison")
-		}
-	case op == "<":
-		switch pt1 {
-		case Integer:
-			t.jasm.AddOpcode("if_icmpge", t.elseLabel)
-			t.pst.Push(Integer)
-		default:
-			t.jasm.AddOpcode("invalid type in comparison")
-		}
-	case op == ">=":
-		switch pt1 {
-		case Integer:
-			t.jasm.AddOpcode("if_icmplt", t.elseLabel)
-			t.pst.Push(Integer)
-		default:
-			t.jasm.AddOpcode("invalid type in comparison")
-		}
-	case op == "<=":
-		switch pt1 {
-		case Integer:
-			t.jasm.AddOpcode("if_icmpgt", t.elseLabel)
-			t.pst.Push(Integer)
-		default:
-			t.jasm.AddOpcode("invalid type in comparison")
-		}
-	case op == "=":
-		switch pt1 {
-		case Integer:
-			t.jasm.AddOpcode("if_icmpne", t.elseLabel)
-			t.pst.Push(Integer)
-		default:
-			t.jasm.AddOpcode("invalid type in comparison")
-		}
-	case op == "<>":
-		switch pt1 {
-		case Integer:
-			t.jasm.AddOpcode("if_icmpeq", t.elseLabel)
-			t.pst.Push(Integer)
-		default:
-			t.jasm.AddOpcode("invalid type in comparison")
-		}
-	}
+	t.jasm.AddOperatorOpcode(op)
 }
 
 func (t *TreeShapeListener) EnterIfStatement(ctx *parsing.IfStatementContext) {
-	t.elseLabel = t.jasm.NewLabel()
-	t.endIfLabel = t.jasm.NewLabel()
+	t.jasm.StartIfStatement()
 }
 
 func (t *TreeShapeListener) ExitIfStatement(ctx *parsing.IfStatementContext) {
-	t.jasm.AddLabel(t.endIfLabel)
+	t.jasm.FinishIfStatement()
 }
 
 func (t *TreeShapeListener) ExitThenStatement(ctx *parsing.ThenStatementContext) {
-	t.jasm.AddOpcode("goto", t.endIfLabel)
-	t.jasm.AddLabel(t.elseLabel)
+	t.jasm.FinishThenStatement()
 }
 
 func (t *TreeShapeListener) ExitUnsignedInteger(ctx *parsing.UnsignedIntegerContext) {
-	t.jasm.AddOpcode("sipush", ctx.GetText())
-	t.pst.Push(Integer)
+	t.jasm.AddSiPushOpcode(ctx.GetText())
 }
 
 func (t *TreeShapeListener) Code() string {


### PR DESCRIPTION
This pull request refactors the code generation package, specifically the `codegen` package in the Go project. The most important changes include the introduction of the `Code` struct, refactoring the `JASM` struct, and simplifying the `TreeShapeListener` struct.

Introduction of `Code` struct:

* [`codegen/code.go`](diffhunk://#diff-8c685d14a0c034d7d506d07bd86c9c389dc1f7517513defdfbb68ee821722a22R1-R35): A new `Code` struct was introduced to manage code generation. This struct includes methods for managing indentation (e.g., `IncTab`, `DecTab`), adding lines of code (`AddLine`), and generating the final code (`Code`). This struct provides a more structured way to manage code generation.

Refactoring of `JASM` struct:

* [`codegen/jasm.go`](diffhunk://#diff-7e6ac7e2ef73be543293dd05fda81f7638f1086b096a1c0aeb2f7d2005367cbaL9-R20): The `JASM` struct was significantly refactored to use the new `Code` struct. This includes changes to the `NewJASM` function to initialize a new `Code` instance, and the replacement of direct string manipulation methods with corresponding methods in the `Code` struct. Additionally, numerous methods were added to the `JASM` struct to handle specific code generation tasks, such as adding opcodes, handling if statements, and generating code for different operators. These changes improve the structure and readability of the `JASM` struct. [[1]](diffhunk://#diff-7e6ac7e2ef73be543293dd05fda81f7638f1086b096a1c0aeb2f7d2005367cbaL9-R20) [[2]](diffhunk://#diff-7e6ac7e2ef73be543293dd05fda81f7638f1086b096a1c0aeb2f7d2005367cbaR45-R184) [[3]](diffhunk://#diff-7e6ac7e2ef73be543293dd05fda81f7638f1086b096a1c0aeb2f7d2005367cbaL60-R251)

Simplification of `TreeShapeListener` struct:

* [`codegen/tree_shape_listener.go`](diffhunk://#diff-2c6f4e667e08fa28b1ce914308e7882e44ae44b7d89fc0c3688430a1b6439146L12-L21): The `TreeShapeListener` struct was simplified by removing unnecessary fields and utilizing the new methods in the `JASM` struct. This includes changes to the `NewTreeShapeListener` function and the removal of direct string manipulation methods. The changes also include the replacement of complex conditional logic with calls to the new methods in the `JASM` struct, which improves the readability of the `TreeShapeListener` struct. [[1]](diffhunk://#diff-2c6f4e667e08fa28b1ce914308e7882e44ae44b7d89fc0c3688430a1b6439146L12-L21) [[2]](diffhunk://#diff-2c6f4e667e08fa28b1ce914308e7882e44ae44b7d89fc0c3688430a1b6439146L39-R54) [[3]](diffhunk://#diff-2c6f4e667e08fa28b1ce914308e7882e44ae44b7d89fc0c3688430a1b6439146L91-R106)