### PR TITLE
refact: conditional tests more verbose

### DIFF
--- a/tests/expected_jasm_files/if_with_integers_with_and_or.jasm
+++ b/tests/expected_jasm_files/if_with_integers_with_and_or.jasm
@@ -2,7 +2,7 @@
 public class if_with_integers_with_and_or {
 	public static main([java/lang/String)V {
 		getstatic java/lang/System.out java/io/PrintStream
-		ldc "2>1? "
+		ldc "2>1 must be true: "
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		sipush 2
 		sipush 1
@@ -27,7 +27,7 @@ public class if_with_integers_with_and_or {
 		invokevirtual java/io/PrintStream.println()V
 		L2:
 		getstatic java/lang/System.out java/io/PrintStream
-		ldc "1>2? "
+		ldc "1>2 must be false: "
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		sipush 1
 		sipush 2
@@ -52,7 +52,7 @@ public class if_with_integers_with_and_or {
 		invokevirtual java/io/PrintStream.println()V
 		L6:
 		getstatic java/lang/System.out java/io/PrintStream
-		ldc "111>222 and 222>333? "
+		ldc "111>222 and 222>333 must be false: "
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		sipush 111
 		sipush 222
@@ -86,7 +86,7 @@ public class if_with_integers_with_and_or {
 		invokevirtual java/io/PrintStream.println()V
 		L10:
 		getstatic java/lang/System.out java/io/PrintStream
-		ldc "111<222 and 222<333? "
+		ldc "111<222 and 222<333 must be true: "
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		sipush 111
 		sipush 222
@@ -120,7 +120,7 @@ public class if_with_integers_with_and_or {
 		invokevirtual java/io/PrintStream.println()V
 		L16:
 		getstatic java/lang/System.out java/io/PrintStream
-		ldc "111>222 and 222<333? "
+		ldc "111>222 and 222<333 must be false: "
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		sipush 111
 		sipush 222
@@ -154,7 +154,7 @@ public class if_with_integers_with_and_or {
 		invokevirtual java/io/PrintStream.println()V
 		L22:
 		getstatic java/lang/System.out java/io/PrintStream
-		ldc "111<222 and 222>333? "
+		ldc "111<222 and 222>333 must be false: "
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		sipush 111
 		sipush 222
@@ -188,7 +188,7 @@ public class if_with_integers_with_and_or {
 		invokevirtual java/io/PrintStream.println()V
 		L28:
 		getstatic java/lang/System.out java/io/PrintStream
-		ldc "111>222 or 222>333? "
+		ldc "111>222 or 222>333 must be false: "
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		sipush 111
 		sipush 222
@@ -222,7 +222,7 @@ public class if_with_integers_with_and_or {
 		invokevirtual java/io/PrintStream.println()V
 		L34:
 		getstatic java/lang/System.out java/io/PrintStream
-		ldc "111<222 or 222<333? "
+		ldc "111<222 or 222<333 must be true: "
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		sipush 111
 		sipush 222
@@ -256,7 +256,7 @@ public class if_with_integers_with_and_or {
 		invokevirtual java/io/PrintStream.println()V
 		L40:
 		getstatic java/lang/System.out java/io/PrintStream
-		ldc "111>222 or 222<333? "
+		ldc "111>222 or 222<333 must be true: "
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		sipush 111
 		sipush 222
@@ -290,7 +290,7 @@ public class if_with_integers_with_and_or {
 		invokevirtual java/io/PrintStream.println()V
 		L46:
 		getstatic java/lang/System.out java/io/PrintStream
-		ldc "111<222 or 222>333? "
+		ldc "111<222 or 222>333 must be true: "
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		sipush 111
 		sipush 222

--- a/tests/expected_jasm_files/if_with_integers_without_and_or.jasm
+++ b/tests/expected_jasm_files/if_with_integers_without_and_or.jasm
@@ -2,7 +2,7 @@
 public class if_with_integers_without_and_or {
 	public static main([java/lang/String)V {
 		getstatic java/lang/System.out java/io/PrintStream
-		ldc "111>222? "
+		ldc "111>222  must be false: "
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		sipush 111
 		sipush 222
@@ -27,7 +27,7 @@ public class if_with_integers_without_and_or {
 		invokevirtual java/io/PrintStream.println()V
 		L2:
 		getstatic java/lang/System.out java/io/PrintStream
-		ldc "333>222? "
+		ldc "333>222 must be true: "
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		sipush 333
 		sipush 222
@@ -52,7 +52,7 @@ public class if_with_integers_without_and_or {
 		invokevirtual java/io/PrintStream.println()V
 		L6:
 		getstatic java/lang/System.out java/io/PrintStream
-		ldc "2>4? "
+		ldc "2>4 must be false: "
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		getstatic java/lang/System.out java/io/PrintStream
 		invokevirtual java/io/PrintStream.println()V
@@ -74,7 +74,7 @@ public class if_with_integers_without_and_or {
 		L9:
 		L10:
 		getstatic java/lang/System.out java/io/PrintStream
-		ldc "4>2? "
+		ldc "4>2 must be true: "
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		sipush 4
 		sipush 2
@@ -94,7 +94,7 @@ public class if_with_integers_without_and_or {
 		L13:
 		L14:
 		getstatic java/lang/System.out java/io/PrintStream
-		ldc "111<222? "
+		ldc "111<222 must be true: "
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		sipush 111
 		sipush 222
@@ -119,7 +119,7 @@ public class if_with_integers_without_and_or {
 		invokevirtual java/io/PrintStream.println()V
 		L18:
 		getstatic java/lang/System.out java/io/PrintStream
-		ldc "222<111? "
+		ldc "222<111 must be false: "
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		sipush 222
 		sipush 111
@@ -144,7 +144,7 @@ public class if_with_integers_without_and_or {
 		invokevirtual java/io/PrintStream.println()V
 		L22:
 		getstatic java/lang/System.out java/io/PrintStream
-		ldc "222>=111? "
+		ldc "222>=111 must be true: "
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		sipush 222
 		sipush 111
@@ -169,7 +169,7 @@ public class if_with_integers_without_and_or {
 		invokevirtual java/io/PrintStream.println()V
 		L26:
 		getstatic java/lang/System.out java/io/PrintStream
-		ldc "111>=222? "
+		ldc "111>=222  must be false: "
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		sipush 111
 		sipush 222
@@ -194,7 +194,7 @@ public class if_with_integers_without_and_or {
 		invokevirtual java/io/PrintStream.println()V
 		L30:
 		getstatic java/lang/System.out java/io/PrintStream
-		ldc "111>=111? "
+		ldc "111>=111 must be true: "
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		sipush 111
 		sipush 111
@@ -219,7 +219,7 @@ public class if_with_integers_without_and_or {
 		invokevirtual java/io/PrintStream.println()V
 		L34:
 		getstatic java/lang/System.out java/io/PrintStream
-		ldc "111<=222? "
+		ldc "111<=222 must be true: "
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		sipush 111
 		sipush 222
@@ -244,7 +244,7 @@ public class if_with_integers_without_and_or {
 		invokevirtual java/io/PrintStream.println()V
 		L38:
 		getstatic java/lang/System.out java/io/PrintStream
-		ldc "222<=111? "
+		ldc "222<=111 must be false: "
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		sipush 222
 		sipush 111
@@ -269,7 +269,7 @@ public class if_with_integers_without_and_or {
 		invokevirtual java/io/PrintStream.println()V
 		L42:
 		getstatic java/lang/System.out java/io/PrintStream
-		ldc "111<=111? "
+		ldc "111<=111 must be true: "
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		sipush 111
 		sipush 111
@@ -294,7 +294,7 @@ public class if_with_integers_without_and_or {
 		invokevirtual java/io/PrintStream.println()V
 		L46:
 		getstatic java/lang/System.out java/io/PrintStream
-		ldc "222=222? "
+		ldc "222=222 must be true: "
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		sipush 222
 		sipush 222
@@ -319,7 +319,7 @@ public class if_with_integers_without_and_or {
 		invokevirtual java/io/PrintStream.println()V
 		L50:
 		getstatic java/lang/System.out java/io/PrintStream
-		ldc "111=222? "
+		ldc "111=222 must be false: "
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		sipush 111
 		sipush 222
@@ -344,7 +344,7 @@ public class if_with_integers_without_and_or {
 		invokevirtual java/io/PrintStream.println()V
 		L54:
 		getstatic java/lang/System.out java/io/PrintStream
-		ldc "111<>222? "
+		ldc "111<>222 must be true: "
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		sipush 111
 		sipush 222
@@ -369,7 +369,7 @@ public class if_with_integers_without_and_or {
 		invokevirtual java/io/PrintStream.println()V
 		L58:
 		getstatic java/lang/System.out java/io/PrintStream
-		ldc "111<>111? "
+		ldc "111<>111 must be false: "
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		sipush 111
 		sipush 111

--- a/tests/pascal_programs/if_with_integers_with_and_or.pas
+++ b/tests/pascal_programs/if_with_integers_with_and_or.pas
@@ -1,63 +1,63 @@
 program IfWithInteger;
 begin
   {* Simple conditional operator. *}
-  write('2>1? ');
+  write('2>1 must be true: ');
   if (2 > 1) then
     writeln('true')
   else
     writeln('false');
 
-  write('1>2? ');
+  write('1>2 must be false: ');
   if (1 > 2) then
     writeln('true')
   else
     writeln('false');
 
   {* AND operator. *}
-  write('111>222 and 222>333? ');
+  write('111>222 and 222>333 must be false: ');
   if ( 111 > 222) and ( 222 > 333 ) then
     writeln('true')
   else
     writeln('false');
 
-  write('111<222 and 222<333? ');
+  write('111<222 and 222<333 must be true: ');
   if ( 111 < 222) and ( 222 < 333 ) then
     writeln('true')
   else
     writeln('false');
 
-  write('111>222 and 222<333? ');
+  write('111>222 and 222<333 must be false: ');
   if ( 111 > 222) and ( 222 < 333 ) then
     writeln('true')
   else
     writeln('false');
 
-  write('111<222 and 222>333? ');
+  write('111<222 and 222>333 must be false: ');
   if ( 111 < 222) and ( 222 > 333 ) then
     writeln('true')
   else
     writeln('false');
   
   {* OR operator. *}
-  write('111>222 or 222>333? ');
+  write('111>222 or 222>333 must be false: ');
   if ( 111 > 222) or ( 222 > 333 ) then
     writeln('true')
   else
     writeln('false');
 
-  write('111<222 or 222<333? ');
+  write('111<222 or 222<333 must be true: ');
   if ( 111 < 222) or ( 222 < 333 ) then
     writeln('true')
   else
     writeln('false');
 
-  write('111>222 or 222<333? ');
+  write('111>222 or 222<333 must be true: ');
   if ( 111 > 222) or ( 222 < 333 ) then
     writeln('true')
   else
     writeln('false');
 
-  write('111<222 or 222>333? ');
+  write('111<222 or 222>333 must be true: ');
   if ( 111 < 222) or ( 222 > 333 ) then
     writeln('true')
   else

--- a/tests/pascal_programs/if_with_integers_without_and_or.pas
+++ b/tests/pascal_programs/if_with_integers_without_and_or.pas
@@ -1,111 +1,110 @@
 program SubIntegers;
 begin
   {* Check > if then sentence (else true). *}
-  write('111>222? ');
+  write('111>222  must be false: ');
   if ( 111 > 222 ) then
     writeln('true')
   else
     writeln('false');
 
   {* Check > if then sentence (then true). *}
-  write('333>222? ');
+  write('333>222 must be true: ');
   if ( 333 > 222 ) then
     writeln('true')
   else
     writeln('false');
 
   {* Check > if sentence (then false). *}
-  writeln('2>4? ');
+  writeln('2>4 must be false: ');
   if ( 2 > 4 ) then
     writeln('true');
 
   {* Check > if sentence (then true). *}
-  write('4>2? ');
+  write('4>2 must be true: ');
   if ( 4 > 2 ) then
     writeln('true');
 
   {* Check < if then sentence (then true). *}
-  write('111<222? ');
+  write('111<222 must be true: ');
   if ( 111 < 222 ) then
     writeln('true')
   else
     writeln('false');
 
   {* Check < if then sentence (else true). *}
-  write('222<111? ');
+  write('222<111 must be false: ');
   if ( 222 < 111 ) then
     writeln('true')
   else
     writeln('false');
 
   {* Check >= if then sentence (then true). *}
-  write('222>=111? ');
+  write('222>=111 must be true: ');
   if ( 222 >= 111 ) then
     writeln('true')
   else
     writeln('false');
 
   {* Check >= if then sentence (else true). *}
-  write('111>=222? ');
+  write('111>=222  must be false: ');
   if ( 111 >= 222 ) then
     writeln('true')
   else
     writeln('false');
 
   {* Check >= if then sentence (then true). *}
-  write('111>=111? ');
+  write('111>=111 must be true: ');
   if ( 111 >= 111 ) then
     writeln('true')
   else
     writeln('false');
 
   {* Check <= if then sentence (then true). *}
-  write('111<=222? ');
+  write('111<=222 must be true: ');
   if ( 111 <= 222 ) then
     writeln('true')
   else
     writeln('false');
 
   {* Check >= if then sentence (else true). *}
-  write('222<=111? ');
+  write('222<=111 must be false: ');
   if ( 222 <= 111 ) then
     writeln('true')
   else
     writeln('false');
 
   {* Check <= if then sentence (then true). *}
-  write('111<=111? ');
+  write('111<=111 must be true: ');
   if ( 111 <= 111 ) then
     writeln('true')
   else
     writeln('false');
 
   {* Check = if then sentence (then true). *}
-  write('222=222? ');
+  write('222=222 must be true: ');
   if ( 222 = 222 ) then
     writeln('true')
   else
     writeln('false');
 
   {* Check = if then sentence (else true). *}
-  write('111=222? ');
+  write('111=222 must be false: ');
   if ( 111 = 222 ) then
     writeln('true')
   else
     writeln('false');
 
   {* Check <> if then sentence (then true). *}
-  write('111<>222? ');
+  write('111<>222 must be true: ');
   if ( 111 <> 222 ) then
     writeln('true')
   else
     writeln('false');
 
   {* Check <> if then sentence (else true). *}
-  write('111<>111? ');
+  write('111<>111 must be false: ');
   if ( 111 <> 111 ) then
     writeln('true')
   else
     writeln('false');
-
 end.


### PR DESCRIPTION
This PR improves the clarity of the output messages in the test files `if_with_integers_with_and_or.jasm`, `if_with_integers_without_and_or.jasm`, `if_with_integers_with_and_or.pas`, and `if_with_integers_without_and_or.pas`. The changes involve modifying the string literals that are written to the console to include the expected result of the conditional checks. 

Changes to `if_with_integers_with_and_or.jasm` and `if_with_integers_without_and_or.jasm`:

* Replaced string literals that are printed to the console to include the expected result of the conditional checks. For example, `"2>1? "` was changed to `"2>1 must be true: "`. This change was made in several places throughout the files. [[1]](diffhunk://#diff-1fa5a65741c07eea3bcfd33e0214d407bc63d4ea0f55ab7b3366fb4ade395c3bL5-R5) [[2]](diffhunk://#diff-1fa5a65741c07eea3bcfd33e0214d407bc63d4ea0f55ab7b3366fb4ade395c3bL30-R30) [[3]](diffhunk://#diff-1fa5a65741c07eea3bcfd33e0214d407bc63d4ea0f55ab7b3366fb4ade395c3bL55-R55) [[4]](diffhunk://#diff-1fa5a65741c07eea3bcfd33e0214d407bc63d4ea0f55ab7b3366fb4ade395c3bL89-R89) [[5]](diffhunk://#diff-1fa5a65741c07eea3bcfd33e0214d407bc63d4ea0f55ab7b3366fb4ade395c3bL123-R123) [[6]](diffhunk://#diff-1fa5a65741c07eea3bcfd33e0214d407bc63d4ea0f55ab7b3366fb4ade395c3bL157-R157) [[7]](diffhunk://#diff-1fa5a65741c07eea3bcfd33e0214d407bc63d4ea0f55ab7b3366fb4ade395c3bL191-R191) [[8]](diffhunk://#diff-1fa5a65741c07eea3bcfd33e0214d407bc63d4ea0f55ab7b3366fb4ade395c3bL225-R225) [[9]](diffhunk://#diff-1fa5a65741c07eea3bcfd33e0214d407bc63d4ea0f55ab7b3366fb4ade395c3bL259-R259) [[10]](diffhunk://#diff-1fa5a65741c07eea3bcfd33e0214d407bc63d4ea0f55ab7b3366fb4ade395c3bL293-R293) [[11]](diffhunk://#diff-ccf8ce54b0f14262f1b7075d68eff3c29e40b6e20915bd05e9f089d1b038a69bL5-R5) [[12]](diffhunk://#diff-ccf8ce54b0f14262f1b7075d68eff3c29e40b6e20915bd05e9f089d1b038a69bL30-R30) [[13]](diffhunk://#diff-ccf8ce54b0f14262f1b7075d68eff3c29e40b6e20915bd05e9f089d1b038a69bL55-R55) [[14]](diffhunk://#diff-ccf8ce54b0f14262f1b7075d68eff3c29e40b6e20915bd05e9f089d1b038a69bL77-R77) [[15]](diffhunk://#diff-ccf8ce54b0f14262f1b7075d68eff3c29e40b6e20915bd05e9f089d1b038a69bL97-R97) [[16]](diffhunk://#diff-ccf8ce54b0f14262f1b7075d68eff3c29e40b6e20915bd05e9f089d1b038a69bL122-R122) [[17]](diffhunk://#diff-ccf8ce54b0f14262f1b7075d68eff3c29e40b6e20915bd05e9f089d1b038a69bL147-R147) [[18]](diffhunk://#diff-ccf8ce54b0f14262f1b7075d68eff3c29e40b6e20915bd05e9f089d1b038a69bL172-R172) [[19]](diffhunk://#diff-ccf8ce54b0f14262f1b7075d68eff3c29e40b6e20915bd05e9f089d1b038a69bL197-R197) [[20]](diffhunk://#diff-ccf8ce54b0f14262f1b7075d68eff3c29e40b6e20915bd05e9f089d1b038a69bL222-R222) [[21]](diffhunk://#diff-ccf8ce54b0f14262f1b7075d68eff3c29e40b6e20915bd05e9f089d1b038a69bL247-R247) [[22]](diffhunk://#diff-ccf8ce54b0f14262f1b7075d68eff3c29e40b6e20915bd05e9f089d1b038a69bL272-R272) [[23]](diffhunk://#diff-ccf8ce54b0f14262f1b7075d68eff3c29e40b6e20915bd05e9f089d1b038a69bL297-R297) [[24]](diffhunk://#diff-ccf8ce54b0f14262f1b7075d68eff3c29e40b6e20915bd05e9f089d1b038a69bL322-R322) [[25]](diffhunk://#diff-ccf8ce54b0f14262f1b7075d68eff3c29e40b6e20915bd05e9f089d1b038a69bL347-R347) [[26]](diffhunk://#diff-ccf8ce54b0f14262f1b7075d68eff3c29e40b6e20915bd05e9f089d1b038a69bL372-R372)

Changes to `if_with_integers_with_and_or.pas` and `if_with_integers_without_and_or.pas`:

* Similar to the `.jasm` files, the string literals that are printed to the console were modified to include the expected result of the conditional checks. For example, `"2>1? "` was changed to `"2>1 must be true: "`. This change was made in several places throughout the files. [[1]](diffhunk://#diff-f0b47a225390d5ee4fa378d4b5779dc5b79059faf99b691bce1eaafbe1d8dd4cL4-R60) [[2]](diffhunk://#diff-8975910974bbf568661db363285f1eb12d9915d6b6e3b241d053ba9c1dfe9e45L4-L110)