### PR TITLE
Feat deal with parser errors

### DIFF
--- a/codegen/error.go
+++ b/codegen/error.go
@@ -1,0 +1,39 @@
+package codegen
+
+import "github.com/antlr4-go/antlr/v4"
+
+type CustomSyntaxError struct {
+	line, column int
+	msg          string
+}
+
+func (c *CustomSyntaxError) Error() string {
+	return c.msg
+}
+
+type CustomErrorListener struct {
+	*antlr.DefaultErrorListener // Embed default which ensures we fit the interface
+	Errors                      []error
+}
+
+func (c *CustomErrorListener) Add(err error) {
+	c.Errors = append(c.Errors, err)
+}
+
+func (c *CustomErrorListener) String() string {
+	var s string
+
+	for _, err := range c.Errors {
+		s += err.Error() + "\n"
+	}
+
+	return s
+}
+
+func (c *CustomErrorListener) SyntaxError(recognizer antlr.Recognizer, offendingSymbol interface{}, line, column int, msg string, e antlr.RecognitionException) {
+	c.Errors = append(c.Errors, &CustomSyntaxError{
+		line:   line,
+		column: column,
+		msg:    msg,
+	})
+}

--- a/codegen/symbol_table.go
+++ b/codegen/symbol_table.go
@@ -1,5 +1,10 @@
 package codegen
 
+import (
+	"fmt"
+	"strings"
+)
+
 type SymbolType uint8
 
 const (
@@ -25,16 +30,24 @@ func NewSymbolTable() *SymbolTable {
 	}
 }
 
-func (st *SymbolTable) AddVariable(name string, ptype PascalType) {
+func (st *SymbolTable) AddVariable(name string, ptype PascalType) error {
+	name = strings.ToUpper(name)
+	if _, ok := st.symbols[name]; ok {
+		return fmt.Errorf("variable %s already declared", name)
+	}
+
 	st.count++
 	st.symbols[name] = Symbol{
 		SymbolType: Variable,
 		PascalType: ptype,
 		Index:      st.count,
 	}
+
+	return nil
 }
 
 func (st *SymbolTable) Get(name string) (bool, Symbol) {
+	name = strings.ToUpper(name)
 	symbol, ok := st.symbols[name]
 	if !ok {
 		return false, Symbol{

--- a/codegen/symbol_table_test.go
+++ b/codegen/symbol_table_test.go
@@ -15,10 +15,24 @@ func TestSymbolTable_AddVariable(t *testing.T) {
 	assert.Equal(t, codegen.Undefined, symbol.PascalType)
 	assert.Equal(t, -1, symbol.Index)
 
-	st.AddVariable("myvar", codegen.Integer)
+	err := st.AddVariable("myvar", codegen.Integer)
+	assert.Nil(t, err)
+
 	ok, symbol = st.Get("myvar")
 	assert.Equal(t, true, ok)
 	assert.Equal(t, codegen.Variable, symbol.SymbolType)
 	assert.Equal(t, codegen.Integer, symbol.PascalType)
 	assert.Equal(t, 1, symbol.Index)
+
+	ok, symbol = st.Get("MyVar")
+	assert.Equal(t, true, ok)
+	assert.Equal(t, codegen.Variable, symbol.SymbolType)
+	assert.Equal(t, codegen.Integer, symbol.PascalType)
+	assert.Equal(t, 1, symbol.Index)
+
+	err = st.AddVariable("myvar", codegen.Integer)
+	assert.NotNil(t, err)
+
+	err = st.AddVariable("MyVar", codegen.Integer)
+	assert.NotNil(t, err)
 }

--- a/codegen/tree_shape_listener.go
+++ b/codegen/tree_shape_listener.go
@@ -6,14 +6,16 @@ import (
 
 type TreeShapeListener struct {
 	*parsing.BasePascalListener
-	filename string
-	jasm     *JASM
+	filename     string
+	jasm         *JASM
+	parserErrors *CustomErrorListener
 }
 
-func NewTreeShapeListener(filename string) *TreeShapeListener {
+func NewTreeShapeListener(filename string, parserErrors *CustomErrorListener) *TreeShapeListener {
 	return &TreeShapeListener{
-		filename: filename,
-		jasm:     NewJASM(),
+		filename:     filename,
+		jasm:         NewJASM(),
+		parserErrors: parserErrors,
 	}
 }
 
@@ -43,7 +45,9 @@ func (t *TreeShapeListener) EnterActualParameter(ctx *parsing.ActualParameterCon
 }
 
 func (t *TreeShapeListener) ExitActualParameter(ctx *parsing.ActualParameterContext) {
-	t.jasm.FinishParameter()
+	if err := t.jasm.FinishParameter(); err != nil {
+		t.parserErrors.Add(err)
+	}
 }
 
 func (t *TreeShapeListener) EnterBlock(ctx *parsing.BlockContext) {
@@ -56,27 +60,37 @@ func (t *TreeShapeListener) ExitBlock(ctx *parsing.BlockContext) {
 
 func (t *TreeShapeListener) ExitNotOp(ctx *parsing.NotOpContext) {
 	op := ctx.GetOp().GetText()
-	t.jasm.AddUnaryOperatorOpcode(op)
+	if err := t.jasm.AddUnaryOperatorOpcode(op); err != nil {
+		t.parserErrors.Add(err)
+	}
 }
 
 func (t *TreeShapeListener) ExitBoolOp(ctx *parsing.BoolOpContext) {
 	op := ctx.GetOp().GetText()
-	t.jasm.AddOperatorOpcode(op)
+	if err := t.jasm.AddOperatorOpcode(op); err != nil {
+		t.parserErrors.Add(err)
+	}
 }
 
 func (t *TreeShapeListener) ExitMulDivOp(ctx *parsing.MulDivOpContext) {
 	op := ctx.GetOp().GetText()
-	t.jasm.AddOperatorOpcode(op)
+	if err := t.jasm.AddOperatorOpcode(op); err != nil {
+		t.parserErrors.Add(err)
+	}
 }
 
 func (t *TreeShapeListener) ExitAddOp(ctx *parsing.AddOpContext) {
 	op := ctx.GetOp().GetText()
-	t.jasm.AddOperatorOpcode(op)
+	if err := t.jasm.AddOperatorOpcode(op); err != nil {
+		t.parserErrors.Add(err)
+	}
 }
 
 func (t *TreeShapeListener) ExitRelOp(ctx *parsing.RelOpContext) {
 	op := ctx.GetOp().GetText()
-	t.jasm.AddOperatorOpcode(op)
+	if err := t.jasm.AddOperatorOpcode(op); err != nil {
+		t.parserErrors.Add(err)
+	}
 }
 
 func (t *TreeShapeListener) EnterIfStatement(ctx *parsing.IfStatementContext) {
@@ -103,18 +117,24 @@ func (t *TreeShapeListener) ExitVariableDeclaration(ctx *parsing.VariableDeclara
 	varNames := ctx.GetVarNames()
 	pascalType := ctx.GetPascalType().GetText()
 	for _, id := range varNames.GetIds() {
-		t.jasm.NewVariable(id.GetText(), pascalType)
+		if err := t.jasm.NewVariable(id.GetText(), pascalType); err != nil {
+			t.parserErrors.Add(err)
+		}
 	}
 }
 
 func (t *TreeShapeListener) ExitAssignmentStatement(ctx *parsing.AssignmentStatementContext) {
 	varName := ctx.GetVarName().GetText()
-	t.jasm.FinishAssignmentStatement(varName)
+	if err := t.jasm.FinishAssignmentStatement(varName); err != nil {
+		t.parserErrors.Add(err)
+	}
 }
 
 func (t *TreeShapeListener) ExitFactorVariable(ctx *parsing.FactorVariableContext) {
 	varName := ctx.GetId().GetText()
-	t.jasm.LoadVarContent(varName)
+	if err := t.jasm.LoadVarContent(varName); err != nil {
+		t.parserErrors.Add(err)
+	}
 }
 
 func (t *TreeShapeListener) EnterRepeatStatement(ctx *parsing.RepeatStatementContext) {

--- a/tests/invalid_pascal_programs/duplicated_variables.errors
+++ b/tests/invalid_pascal_programs/duplicated_variables.errors
@@ -1,0 +1,2 @@
+variable I already declared
+variable X already declared

--- a/tests/invalid_pascal_programs/duplicated_variables.pas
+++ b/tests/invalid_pascal_programs/duplicated_variables.pas
@@ -1,0 +1,9 @@
+program InvalidExample;
+var
+  i : integer;
+  x : string;
+  i : string;
+  X : string;
+begin
+  writeln('true');
+end.

--- a/tests/invalid_pascal_programs/for_with_undefined_variable.errors
+++ b/tests/invalid_pascal_programs/for_with_undefined_variable.errors
@@ -1,0 +1,1 @@
+variable i not found

--- a/tests/invalid_pascal_programs/for_with_undefined_variable.pas
+++ b/tests/invalid_pascal_programs/for_with_undefined_variable.pas
@@ -1,0 +1,7 @@
+program InvalidExample;
+begin
+  for i := 10 to 19 do
+  begin
+    writeln ('inc i=', i);
+  end;
+end.

--- a/tests/invalid_pascal_programs/invalid_operators.errors
+++ b/tests/invalid_pascal_programs/invalid_operators.errors
@@ -1,0 +1,6 @@
+invalid type in < operator: string
+invalid types in operator and: boolean and undefined
+invalid types in operator <: string and integer
+invalid types in operator +: boolean and string
+invalid type in < operator: string
+invalid types in operator -: string and undefined

--- a/tests/invalid_pascal_programs/invalid_operators.pas
+++ b/tests/invalid_pascal_programs/invalid_operators.pas
@@ -1,0 +1,16 @@
+program InvalidExample;
+begin
+  if ( 111 < 222) and ( 'a' < 'b' ) then
+    writeln('true')
+  else
+    writeln('false');
+
+  if ( 111 < 'a' ) then
+    writeln('true');
+  
+  if ( 'a' + 2 < 5 ) then
+    writeln('true');
+
+  if ( 'a' - 'b' < 'c' ) then
+    writeln('true');
+end.

--- a/tests/invalid_pascal_programs/invalid_token.errors
+++ b/tests/invalid_pascal_programs/invalid_token.errors
@@ -1,0 +1,2 @@
+missing 'PROGRAM' at 'progxram'
+extraneous input 'InvalidExample' expecting ';'

--- a/tests/invalid_pascal_programs/invalid_token.pas
+++ b/tests/invalid_pascal_programs/invalid_token.pas
@@ -1,0 +1,4 @@
+progxram InvalidExample;
+begin
+  writeln ('Hello world!');
+end.

--- a/tests/invalid_pascal_programs/without_end.errors
+++ b/tests/invalid_pascal_programs/without_end.errors
@@ -1,0 +1,1 @@
+no viable alternative at input '<EOF>'

--- a/tests/invalid_pascal_programs/without_end.pas
+++ b/tests/invalid_pascal_programs/without_end.pas
@@ -1,0 +1,3 @@
+program InvalidExample;
+begin
+  writeln ('Hello world!');


### PR DESCRIPTION
This PR improves lexer and parser error handling and reporting. The changes involve introducing a new `CustomSyntaxError` type and `CustomErrorListener` struct in `codegen/error.go`, modifying various functions in `codegen/jasm.go` and `codegen/tree_shape_listener.go` to return errors, and updating the `genCode` function in `main.go` to handle and report lexer and parser errors.

Error handling improvements:

* [`codegen/error.go`](diffhunk://#diff-fc3dce71fa52049ca18b31e3b98954f62de1136538074dbaf281b3a837382853R1-R39): Introduced a `CustomSyntaxError` type and `CustomErrorListener` struct to handle and collect syntax errors.
* [`codegen/jasm.go`](diffhunk://#diff-7e6ac7e2ef73be543293dd05fda81f7638f1086b096a1c0aeb2f7d2005367cbaL62-R71): Modified various functions to return errors, including `FinishParameter`, `FinishForInit`, `FinishForStatement`, `AddOperatorOpcode`, `AddUnaryOperatorOpcode`, `NewVariable`, `FinishAssignmentStatement`, `LoadVarContent`, and `addInvokeVirtualPrintWithType`. [[1]](diffhunk://#diff-7e6ac7e2ef73be543293dd05fda81f7638f1086b096a1c0aeb2f7d2005367cbaL62-R71) [[2]](diffhunk://#diff-7e6ac7e2ef73be543293dd05fda81f7638f1086b096a1c0aeb2f7d2005367cbaL134-R192) [[3]](diffhunk://#diff-7e6ac7e2ef73be543293dd05fda81f7638f1086b096a1c0aeb2f7d2005367cbaL181-R224) [[4]](diffhunk://#diff-7e6ac7e2ef73be543293dd05fda81f7638f1086b096a1c0aeb2f7d2005367cbaL212-R292) [[5]](diffhunk://#diff-7e6ac7e2ef73be543293dd05fda81f7638f1086b096a1c0aeb2f7d2005367cbaR306-R325) [[6]](diffhunk://#diff-7e6ac7e2ef73be543293dd05fda81f7638f1086b096a1c0aeb2f7d2005367cbaL307-R347) [[7]](diffhunk://#diff-7e6ac7e2ef73be543293dd05fda81f7638f1086b096a1c0aeb2f7d2005367cbaL325-R359) [[8]](diffhunk://#diff-7e6ac7e2ef73be543293dd05fda81f7638f1086b096a1c0aeb2f7d2005367cbaL366-R410)
* [`codegen/symbol_table.go`](diffhunk://#diff-d35fdb0677a119bfe86ee05f62384dab686f1d34641233b054c3d9868fa2a1a6L28-R50): Updated `AddVariable` function to return an error when a variable is already declared.
* [`codegen/tree_shape_listener.go`](diffhunk://#diff-2c6f4e667e08fa28b1ce914308e7882e44ae44b7d89fc0c3688430a1b6439146R11-R18): Updated various functions to handle errors returned by functions in `jasm.go` and add them to `parserErrors`. [[1]](diffhunk://#diff-2c6f4e667e08fa28b1ce914308e7882e44ae44b7d89fc0c3688430a1b6439146R11-R18) [[2]](diffhunk://#diff-2c6f4e667e08fa28b1ce914308e7882e44ae44b7d89fc0c3688430a1b6439146L46-R50) [[3]](diffhunk://#diff-2c6f4e667e08fa28b1ce914308e7882e44ae44b7d89fc0c3688430a1b6439146L59-R93) [[4]](diffhunk://#diff-2c6f4e667e08fa28b1ce914308e7882e44ae44b7d89fc0c3688430a1b6439146L106-R137)
* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L26-R86): Updated `genCode` function to handle and report lexer and parser errors.

Testing improvements:

* [`main_test.go`](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eR10-R13): Updated `Test_genCode` function to handle the changes in `genCode` function and added new test function `Test_InvalidPascalPrograms` to test invalid Pascal programs. [[1]](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eR10-R13) [[2]](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eL26-R27) [[3]](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eR45-R81)
* `tests/invalid_pascal_programs/duplicated_variables.pas`, `tests/invalid_pascal_programs/duplicated_variables.errors`, `tests/invalid_pascal_programs/for_with_undefined_variable.pas`, `tests/invalid_pascal_programs/for_with_undefined_variable.errors`: Added new test cases for invalid Pascal programs. [[1]](diffhunk://#diff-6ba0deeb0623cd97f0ce3ede04dadc56c9d4fff801e661a8f165bb27012d8ad3R1-R9) [[2]](diffhunk://#diff-f5784c3915fa529a4008cc29df0f196b8650226c436bca3c572a8cb16fbd73f3R1-R2) [[3]](diffhunk://#diff-ad4ad4631b9dc5b73e8ae564d6c32bc1c2709711775c69990f8873a8ec739237R1-R7) [[4]](diffhunk://#diff-c6fd2b795e1956e5160120878e2d1ae93cbed2a99813550c1940ff02240b598fR1)