### PR TITLE
Refact operators

### DIFF
--- a/codegen/tree_shape_listener.go
+++ b/codegen/tree_shape_listener.go
@@ -67,28 +67,28 @@ func (t *TreeShapeListener) ExitNotOp(ctx *parsing.NotOpContext) {
 
 func (t *TreeShapeListener) ExitBoolOp(ctx *parsing.BoolOpContext) {
 	op := ctx.GetOp().GetText()
-	if err := t.jasm.AddOperatorOpcode(op); err != nil {
+	if err := t.jasm.AddBooleanOperatorOpcode(op); err != nil {
 		t.parserErrors.Add(err)
 	}
 }
 
 func (t *TreeShapeListener) ExitMulDivOp(ctx *parsing.MulDivOpContext) {
 	op := ctx.GetOp().GetText()
-	if err := t.jasm.AddOperatorOpcode(op); err != nil {
+	if err := t.jasm.AddMulDivOperatorOpcode(op); err != nil {
 		t.parserErrors.Add(err)
 	}
 }
 
-func (t *TreeShapeListener) ExitAddOp(ctx *parsing.AddOpContext) {
+func (t *TreeShapeListener) ExitAddSubOp(ctx *parsing.AddSubOpContext) {
 	op := ctx.GetOp().GetText()
-	if err := t.jasm.AddOperatorOpcode(op); err != nil {
+	if err := t.jasm.AddAddSubOperatorOpcode(op); err != nil {
 		t.parserErrors.Add(err)
 	}
 }
 
 func (t *TreeShapeListener) ExitRelOp(ctx *parsing.RelOpContext) {
 	op := ctx.GetOp().GetText()
-	if err := t.jasm.AddOperatorOpcode(op); err != nil {
+	if err := t.jasm.AddRelationalOperatorOpcode(op); err != nil {
 		t.parserErrors.Add(err)
 	}
 }

--- a/parser/Pascal.g4
+++ b/parser/Pascal.g4
@@ -298,7 +298,7 @@ expression
     | expression op = (AND | OR) expression         # BoolOp
     | expression op = relationaloperator expression # RelOp
     | expression op = (STAR | SLASH) expression     # MulDivOp
-    | expression op = additiveoperator expression   # AddOp
+    | expression op = addsuboperator expression     # AddSubOp
     | signedFactor                                  # ExpSignedFactor
     ;
 
@@ -312,7 +312,7 @@ relationaloperator
     | IN
     ;
 
-additiveoperator
+addsuboperator
     : PLUS
     | MINUS
     | OR

--- a/tests/invalid_pascal_programs/invalid_operators.errors
+++ b/tests/invalid_pascal_programs/invalid_operators.errors
@@ -1,3 +1,3 @@
-invalid types in operator <: string and integer
-invalid types in operator +: boolean and string
-invalid types in operator -: boolean and string
+invalid types in < operator: string and integer
+invalid types in + operator: boolean and string
+invalid types in - operator: boolean and string


### PR DESCRIPTION
This pull request primarily refactors the `codegen/jasm.go` and `codegen/tree_shape_listener.go` files in the `JASM` package, with changes aimed at improving code readability and maintainability. The changes involve renaming functions, extracting repeated code into separate functions, and modifying the way opcodes are added. There are also corresponding changes in the `parser/Pascal.g4` file and the `tests/invalid_pascal_programs/invalid_operators.errors` file to align with the refactoring.

Refactoring:

* [`codegen/jasm.go`](diffhunk://#diff-7e6ac7e2ef73be543293dd05fda81f7638f1086b096a1c0aeb2f7d2005367cbaL50-R50): Renamed various functions for better clarity and consistency, such as changing `addPushTrue` to `addPushTrueOpcode`. Extracted repeated code into separate functions, like `addIAddOpcode`, `addISubOpcode`, `addIMulOpcode`, and others. Modified the way opcodes are added in functions like `FinishProcedureStatement`, `EnterThenStatement`, `FinishThenStatement`, and others. [[1]](diffhunk://#diff-7e6ac7e2ef73be543293dd05fda81f7638f1086b096a1c0aeb2f7d2005367cbaL50-R50) [[2]](diffhunk://#diff-7e6ac7e2ef73be543293dd05fda81f7638f1086b096a1c0aeb2f7d2005367cbaL102-R106) [[3]](diffhunk://#diff-7e6ac7e2ef73be543293dd05fda81f7638f1086b096a1c0aeb2f7d2005367cbaL120-R120) [[4]](diffhunk://#diff-7e6ac7e2ef73be543293dd05fda81f7638f1086b096a1c0aeb2f7d2005367cbaL135-R135) [[5]](diffhunk://#diff-7e6ac7e2ef73be543293dd05fda81f7638f1086b096a1c0aeb2f7d2005367cbaL173-R175) [[6]](diffhunk://#diff-7e6ac7e2ef73be543293dd05fda81f7638f1086b096a1c0aeb2f7d2005367cbaL188-R294) [[7]](diffhunk://#diff-7e6ac7e2ef73be543293dd05fda81f7638f1086b096a1c0aeb2f7d2005367cbaL317-R314) [[8]](diffhunk://#diff-7e6ac7e2ef73be543293dd05fda81f7638f1086b096a1c0aeb2f7d2005367cbaL405-L434) [[9]](diffhunk://#diff-7e6ac7e2ef73be543293dd05fda81f7638f1086b096a1c0aeb2f7d2005367cbaL476-R510)

* [`codegen/tree_shape_listener.go`](diffhunk://#diff-2c6f4e667e08fa28b1ce914308e7882e44ae44b7d89fc0c3688430a1b6439146L70-R91): Updated function calls to match the renamed functions in `jasm.go`. For example, `AddOperatorOpcode` has been replaced with more specific calls like `AddBooleanOperatorOpcode`, `AddMulDivOperatorOpcode`, `AddAddSubOperatorOpcode`, and `AddRelationalOperatorOpcode`.

Changes to align with refactoring:

* [`parser/Pascal.g4`](diffhunk://#diff-655d41bed5a1a0eb30151dacd68aa85ad7aff1cb50873d4226cb9d0b1caaf912L301-R301): Renamed `additiveoperator` to `addsuboperator` to match the changes in `jasm.go` and `tree_shape_listener.go`. [[1]](diffhunk://#diff-655d41bed5a1a0eb30151dacd68aa85ad7aff1cb50873d4226cb9d0b1caaf912L301-R301) [[2]](diffhunk://#diff-655d41bed5a1a0eb30151dacd68aa85ad7aff1cb50873d4226cb9d0b1caaf912L315-R315)

* [`tests/invalid_pascal_programs/invalid_operators.errors`](diffhunk://#diff-18ae90279f8ed1dd9a04d4b9dfb5f4469786cfb3a0ed1f00ce7ec5bf42b8e91dL1-R3): Updated error messages to match the changes in `jasm.go` and `tree_shape_listener.go`.