### PR TITLE
Feat better error output

### DIFF
--- a/codegen/error.go
+++ b/codegen/error.go
@@ -1,6 +1,10 @@
 package codegen
 
-import "github.com/antlr4-go/antlr/v4"
+import (
+	"fmt"
+
+	"github.com/antlr4-go/antlr/v4"
+)
 
 type CustomSyntaxError struct {
 	line, column int
@@ -16,8 +20,8 @@ type CustomErrorListener struct {
 	Errors                      []error
 }
 
-func (c *CustomErrorListener) Add(err error) {
-	c.Errors = append(c.Errors, err)
+func (c *CustomErrorListener) Add(line int, err error) {
+	c.Errors = append(c.Errors, fmt.Errorf("line %d: %s", line, err))
 }
 
 func (c *CustomErrorListener) String() string {

--- a/codegen/stack.go
+++ b/codegen/stack.go
@@ -36,3 +36,7 @@ func (s *Stack[T]) Top() (T, bool) {
 
 	return elem, true
 }
+
+func (s *Stack[T]) Size() int {
+	return len(s.elements)
+}

--- a/codegen/tree_shape_listener.go
+++ b/codegen/tree_shape_listener.go
@@ -44,54 +44,54 @@ func (t *TreeShapeListener) ExitString(ctx *parsing.StringContext) {
 
 func (t *TreeShapeListener) EnterActualParameter(ctx *parsing.ActualParameterContext) {
 	if err := t.jasm.StartParameter(); err != nil {
-		t.parserErrors.Add(err)
+		t.parserErrors.Add(ctx.GetStart().GetLine(), err)
 	}
 }
 
 func (t *TreeShapeListener) ExitActualParameter(ctx *parsing.ActualParameterContext) {
 	if err := t.jasm.FinishParameter(); err != nil {
-		t.parserErrors.Add(err)
+		t.parserErrors.Add(ctx.GetStart().GetLine(), err)
 	}
 }
 
 func (t *TreeShapeListener) EnterCompoundStatement(ctx *parsing.CompoundStatementContext) {
 	if err := t.jasm.StartMainBlock(); err != nil {
-		t.parserErrors.Add(err)
+		t.parserErrors.Add(ctx.GetStart().GetLine(), err)
 	}
 }
 
 func (t *TreeShapeListener) ExitNotOp(ctx *parsing.NotOpContext) {
 	op := ctx.GetOp().GetText()
 	if err := t.jasm.AddUnaryOperatorOpcode(op); err != nil {
-		t.parserErrors.Add(err)
+		t.parserErrors.Add(ctx.GetStart().GetLine(), err)
 	}
 }
 
 func (t *TreeShapeListener) ExitBoolOp(ctx *parsing.BoolOpContext) {
 	op := ctx.GetOp().GetText()
 	if err := t.jasm.AddBooleanOperatorOpcode(op); err != nil {
-		t.parserErrors.Add(err)
+		t.parserErrors.Add(ctx.GetStart().GetLine(), err)
 	}
 }
 
 func (t *TreeShapeListener) ExitMulDivOp(ctx *parsing.MulDivOpContext) {
 	op := ctx.GetOp().GetText()
 	if err := t.jasm.AddMulDivOperatorOpcode(op); err != nil {
-		t.parserErrors.Add(err)
+		t.parserErrors.Add(ctx.GetStart().GetLine(), err)
 	}
 }
 
 func (t *TreeShapeListener) ExitAddSubOp(ctx *parsing.AddSubOpContext) {
 	op := ctx.GetOp().GetText()
 	if err := t.jasm.AddAddSubOperatorOpcode(op); err != nil {
-		t.parserErrors.Add(err)
+		t.parserErrors.Add(ctx.GetStart().GetLine(), err)
 	}
 }
 
 func (t *TreeShapeListener) ExitRelOp(ctx *parsing.RelOpContext) {
 	op := ctx.GetOp().GetText()
 	if err := t.jasm.AddRelationalOperatorOpcode(op); err != nil {
-		t.parserErrors.Add(err)
+		t.parserErrors.Add(ctx.GetStart().GetLine(), err)
 	}
 }
 
@@ -120,7 +120,7 @@ func (t *TreeShapeListener) ExitVariableDeclaration(ctx *parsing.VariableDeclara
 	pascalType := ctx.GetPascalType().GetText()
 	for _, id := range varNames.GetIds() {
 		if err := t.jasm.NewVariable(id.GetText(), pascalType); err != nil {
-			t.parserErrors.Add(err)
+			t.parserErrors.Add(ctx.GetStart().GetLine(), err)
 		}
 	}
 }
@@ -128,14 +128,14 @@ func (t *TreeShapeListener) ExitVariableDeclaration(ctx *parsing.VariableDeclara
 func (t *TreeShapeListener) ExitAssignmentStatement(ctx *parsing.AssignmentStatementContext) {
 	varName := ctx.GetVarName().GetText()
 	if err := t.jasm.FinishAssignmentStatement(varName); err != nil {
-		t.parserErrors.Add(err)
+		t.parserErrors.Add(ctx.GetStart().GetLine(), err)
 	}
 }
 
 func (t *TreeShapeListener) ExitFactorVariable(ctx *parsing.FactorVariableContext) {
 	varName := ctx.GetId().GetText()
 	if err := t.jasm.LoadVarContent(varName); err != nil {
-		t.parserErrors.Add(err)
+		t.parserErrors.Add(ctx.GetStart().GetLine(), err)
 	}
 }
 
@@ -186,7 +186,7 @@ func (t *TreeShapeListener) EnterProcedureDeclaration(ctx *parsing.ProcedureDecl
 	}
 
 	if err := t.jasm.NewProcedure(procName, paramTypes); err != nil {
-		t.parserErrors.Add(err)
+		t.parserErrors.Add(ctx.GetStart().GetLine(), err)
 	}
 
 	t.jasm.StartProcedureDeclaration(procName, paramTypes)
@@ -213,7 +213,7 @@ func (t *TreeShapeListener) EnterFunctionDeclaration(ctx *parsing.FunctionDeclar
 	returnType := ctx.GetReturnType().GetText()
 
 	if err := t.jasm.NewFunction(funcName, paramTypes, returnType); err != nil {
-		t.parserErrors.Add(err)
+		t.parserErrors.Add(ctx.GetStart().GetLine(), err)
 	}
 
 	t.jasm.StartFunctionDeclaration(funcName, paramTypes, returnType)
@@ -228,7 +228,7 @@ func (t *TreeShapeListener) EnterFormalParameterSection(ctx *parsing.FormalParam
 	pascalType := ctx.GetParamType().GetText()
 	for _, id := range params.GetIds() {
 		if err := t.jasm.NewVariable(id.GetText(), pascalType); err != nil {
-			t.parserErrors.Add(err)
+			t.parserErrors.Add(ctx.GetStart().GetLine(), err)
 		}
 	}
 }
@@ -240,12 +240,13 @@ func (t *TreeShapeListener) EnterFunctionDesignator(ctx *parsing.FunctionDesigna
 func (t *TreeShapeListener) ExitFunctionDesignator(ctx *parsing.FunctionDesignatorContext) {
 	funcName := ctx.GetFunctionID().GetText()
 	if err := t.jasm.CallFunction(funcName); err != nil {
-		t.parserErrors.Add(err)
+		t.parserErrors.Add(ctx.GetStart().GetLine(), err)
 	}
 
+	// TODO: refactor
 	_, exists := t.jasm.procedureStatementContext.Pop()
 	if !exists {
-		t.parserErrors.Add(fmt.Errorf("during pop procedure statement context"))
+		t.parserErrors.Add(ctx.GetStart().GetLine(), fmt.Errorf("during pop procedure statement context"))
 	}
 }
 

--- a/tests/invalid_pascal_programs/duplicated_variables.errors
+++ b/tests/invalid_pascal_programs/duplicated_variables.errors
@@ -1,2 +1,2 @@
-variable i already declared
-variable X already declared
+line 5: variable i already declared
+line 6: variable X already declared

--- a/tests/invalid_pascal_programs/for_with_undefined_variable.errors
+++ b/tests/invalid_pascal_programs/for_with_undefined_variable.errors
@@ -1,1 +1,1 @@
-variable i not found
+line 5: variable i not found

--- a/tests/invalid_pascal_programs/invalid_operators.errors
+++ b/tests/invalid_pascal_programs/invalid_operators.errors
@@ -1,3 +1,3 @@
-invalid types in < operator: string and integer
-invalid types in + operator: boolean and string
-invalid types in - operator: boolean and string
+line 3: invalid types in < operator: string and integer
+line 6: invalid types in + operator: boolean and string
+line 9: invalid types in - operator: boolean and string


### PR DESCRIPTION
This PR enhances error handling and reporting. The changes include adding line numbers to error messages, and updates to test files to reflect these changes.

Error Handling Enhancements:

* [`codegen/error.go`](diffhunk://#diff-fc3dce71fa52049ca18b31e3b98954f62de1136538074dbaf281b3a837382853L3-R7): Imported the `fmt` package and modified the `Add` method in the `CustomErrorListener` struct to include line numbers in error messages. [[1]](diffhunk://#diff-fc3dce71fa52049ca18b31e3b98954f62de1136538074dbaf281b3a837382853L3-R7) [[2]](diffhunk://#diff-fc3dce71fa52049ca18b31e3b98954f62de1136538074dbaf281b3a837382853L19-R24)

* [`codegen/tree_shape_listener.go`](diffhunk://#diff-2c6f4e667e08fa28b1ce914308e7882e44ae44b7d89fc0c3688430a1b6439146L47-R94): Updated multiple methods in the `TreeShapeListener` struct to pass line numbers when adding errors. This allows for more precise error reporting. [[1]](diffhunk://#diff-2c6f4e667e08fa28b1ce914308e7882e44ae44b7d89fc0c3688430a1b6439146L47-R94) [[2]](diffhunk://#diff-2c6f4e667e08fa28b1ce914308e7882e44ae44b7d89fc0c3688430a1b6439146L123-R138) [[3]](diffhunk://#diff-2c6f4e667e08fa28b1ce914308e7882e44ae44b7d89fc0c3688430a1b6439146L189-R189) [[4]](diffhunk://#diff-2c6f4e667e08fa28b1ce914308e7882e44ae44b7d89fc0c3688430a1b6439146L216-R216) [[5]](diffhunk://#diff-2c6f4e667e08fa28b1ce914308e7882e44ae44b7d89fc0c3688430a1b6439146L231-R231) [[6]](diffhunk://#diff-2c6f4e667e08fa28b1ce914308e7882e44ae44b7d89fc0c3688430a1b6439146L243-R249)

Codebase Enhancement:

* [`codegen/stack.go`](diffhunk://#diff-8fe25ebea85330b6d1e9f582e6aa99c177ba69bc4dca18900bdd9ccf74faf19dR39-R42): Added a `Size` method to the `Stack` type, which returns the number of elements in the stack. This can be useful for checking if the stack is empty or for other size-related operations.

Test File Updates:

* Various test files in `tests/invalid_pascal_programs`: Updated expected error messages to include line numbers, reflecting the changes made to error reporting. [[1]](diffhunk://#diff-f5784c3915fa529a4008cc29df0f196b8650226c436bca3c572a8cb16fbd73f3L1-R2) [[2]](diffhunk://#diff-c6fd2b795e1956e5160120878e2d1ae93cbed2a99813550c1940ff02240b598fL1-R1) [[3]](diffhunk://#diff-18ae90279f8ed1dd9a04d4b9dfb5f4469786cfb3a0ed1f00ce7ec5bf42b8e91dL1-R3)