### PR TITLE
Remove useless space in jasm

### DIFF
--- a/codegen/jasm.go
+++ b/codegen/jasm.go
@@ -551,11 +551,11 @@ func (j *JASM) addSiPushOpcode(number string) {
 }
 
 func (j *JASM) addPushTrueOpcode() {
-	j.addOpcode("iconst 1")
+	j.addOpcode("iconst", "1")
 }
 
 func (j *JASM) addPushFalseOpcode() {
-	j.addOpcode("iconst 0")
+	j.addOpcode("iconst", "0")
 }
 
 func (j *JASM) addIAddOpcode() {

--- a/codegen/jasm.go
+++ b/codegen/jasm.go
@@ -659,6 +659,7 @@ func (j *JASM) finishInvokeDynamic() {
 }
 
 func (j *JASM) addLine(line string) {
+	line = strings.Trim(line, " ")
 	j.code.AddLine(line)
 }
 

--- a/tests/valid_pascal_programs/add_three_numbers.jasm
+++ b/tests/valid_pascal_programs/add_three_numbers.jasm
@@ -4,9 +4,9 @@ public class add_three_numbers {
 		getstatic java/lang/System.out java/io/PrintStream
 		sipush 1
 		sipush 2
-		iadd 
+		iadd
 		sipush 3
-		iadd 
+		iadd
 		invokevirtual java/io/PrintStream.print(I)V
 		getstatic java/lang/System.out java/io/PrintStream
 		invokevirtual java/io/PrintStream.println()V

--- a/tests/valid_pascal_programs/add_two_numbers.jasm
+++ b/tests/valid_pascal_programs/add_two_numbers.jasm
@@ -4,7 +4,7 @@ public class add_two_numbers {
 		getstatic java/lang/System.out java/io/PrintStream
 		sipush 1
 		sipush 2
-		iadd 
+		iadd
 		invokevirtual java/io/PrintStream.print(I)V
 		getstatic java/lang/System.out java/io/PrintStream
 		invokevirtual java/io/PrintStream.println()V

--- a/tests/valid_pascal_programs/all_numeric_operators.jasm
+++ b/tests/valid_pascal_programs/all_numeric_operators.jasm
@@ -4,22 +4,22 @@ public class all_numeric_operators {
 		getstatic java/lang/System.out java/io/PrintStream
 		sipush 1
 		sipush 1
-		iadd 
+		iadd
 		invokevirtual java/io/PrintStream.print(I)V
 		getstatic java/lang/System.out java/io/PrintStream
 		sipush 2
 		sipush 2
-		isub 
+		isub
 		invokevirtual java/io/PrintStream.print(I)V
 		getstatic java/lang/System.out java/io/PrintStream
 		sipush 3
 		sipush 3
-		imul 
+		imul
 		invokevirtual java/io/PrintStream.print(I)V
 		getstatic java/lang/System.out java/io/PrintStream
 		sipush 4
 		sipush 4
-		idiv 
+		idiv
 		invokevirtual java/io/PrintStream.print(I)V
 		getstatic java/lang/System.out java/io/PrintStream
 		invokevirtual java/io/PrintStream.println()V

--- a/tests/valid_pascal_programs/concat_three_strings.jasm
+++ b/tests/valid_pascal_programs/concat_three_strings.jasm
@@ -5,13 +5,13 @@ public class concat_three_strings {
 		ldc "Hello "
 		ldc "world "
 		invokedynamic makeConcatWithConstants(java/lang/String, java/lang/String)java/lang/String {
-			invokestatic java/lang/invoke/StringConcatFactory.makeConcatWithConstants(java/lang/invoke/MethodHandles$Lookup, java/lang/String, java/lang/invoke/MethodType, java/lang/String, [java/lang/Object)java/lang/invoke/CallSite 
-			[""] 
+			invokestatic java/lang/invoke/StringConcatFactory.makeConcatWithConstants(java/lang/invoke/MethodHandles$Lookup, java/lang/String, java/lang/invoke/MethodType, java/lang/String, [java/lang/Object)java/lang/invoke/CallSite
+			[""]
 		}
 		ldc "again!"
 		invokedynamic makeConcatWithConstants(java/lang/String, java/lang/String)java/lang/String {
-			invokestatic java/lang/invoke/StringConcatFactory.makeConcatWithConstants(java/lang/invoke/MethodHandles$Lookup, java/lang/String, java/lang/invoke/MethodType, java/lang/String, [java/lang/Object)java/lang/invoke/CallSite 
-			[""] 
+			invokestatic java/lang/invoke/StringConcatFactory.makeConcatWithConstants(java/lang/invoke/MethodHandles$Lookup, java/lang/String, java/lang/invoke/MethodType, java/lang/String, [java/lang/Object)java/lang/invoke/CallSite
+			[""]
 		}
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		getstatic java/lang/System.out java/io/PrintStream

--- a/tests/valid_pascal_programs/concat_two_strings.jasm
+++ b/tests/valid_pascal_programs/concat_two_strings.jasm
@@ -5,8 +5,8 @@ public class concat_two_strings {
 		ldc "Hello "
 		ldc "world!"
 		invokedynamic makeConcatWithConstants(java/lang/String, java/lang/String)java/lang/String {
-			invokestatic java/lang/invoke/StringConcatFactory.makeConcatWithConstants(java/lang/invoke/MethodHandles$Lookup, java/lang/String, java/lang/invoke/MethodType, java/lang/String, [java/lang/Object)java/lang/invoke/CallSite 
-			[""] 
+			invokestatic java/lang/invoke/StringConcatFactory.makeConcatWithConstants(java/lang/invoke/MethodHandles$Lookup, java/lang/String, java/lang/invoke/MethodType, java/lang/String, [java/lang/Object)java/lang/invoke/CallSite
+			[""]
 		}
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		getstatic java/lang/System.out java/io/PrintStream

--- a/tests/valid_pascal_programs/div_three_numbers.jasm
+++ b/tests/valid_pascal_programs/div_three_numbers.jasm
@@ -4,9 +4,9 @@ public class div_three_numbers {
 		getstatic java/lang/System.out java/io/PrintStream
 		sipush 60
 		sipush 5
-		idiv 
+		idiv
 		sipush 3
-		idiv 
+		idiv
 		invokevirtual java/io/PrintStream.print(I)V
 		getstatic java/lang/System.out java/io/PrintStream
 		invokevirtual java/io/PrintStream.println()V

--- a/tests/valid_pascal_programs/fatorial.jasm
+++ b/tests/valid_pascal_programs/fatorial.jasm
@@ -31,14 +31,14 @@ public class fatorial {
 		iload 0
 		iload 0
 		sipush 1
-		isub 
-		invokestatic fatorial.fatorial(I)I 
-		imul 
+		isub
+		invokestatic fatorial.fatorial(I)I
+		imul
 		istore 100
 		L7:
 		L2:
 		iload 100
-		ireturn 
+		ireturn
 	}
 	public static main([java/lang/String)V {
 		getstatic java/lang/System.out java/io/PrintStream
@@ -61,7 +61,7 @@ public class fatorial {
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		getstatic java/lang/System.out java/io/PrintStream
 		getstatic fatorial.numero I
-		invokestatic fatorial.fatorial(I)I 
+		invokestatic fatorial.fatorial(I)I
 		invokevirtual java/io/PrintStream.print(I)V
 		getstatic java/lang/System.out java/io/PrintStream
 		invokevirtual java/io/PrintStream.println()V

--- a/tests/valid_pascal_programs/fatorial.jasm
+++ b/tests/valid_pascal_programs/fatorial.jasm
@@ -5,10 +5,10 @@ public class fatorial {
 		iload 0
 		sipush 0
 		if_icmpge L4
-		iconst 1 
+		iconst 1
 		goto L5
 		L4:
-		iconst 0 
+		iconst 0
 		L5:
 		ifeq L1
 		sipush 0
@@ -18,10 +18,10 @@ public class fatorial {
 		iload 0
 		sipush 1
 		if_icmpgt L9
-		iconst 1 
+		iconst 1
 		goto L10
 		L9:
-		iconst 0 
+		iconst 0
 		L10:
 		ifeq L6
 		sipush 1

--- a/tests/valid_pascal_programs/fatorial_fixed_number.jasm
+++ b/tests/valid_pascal_programs/fatorial_fixed_number.jasm
@@ -31,14 +31,14 @@ public class fatorial_fixed_number {
 		iload 0
 		iload 0
 		sipush 1
-		isub 
-		invokestatic fatorial_fixed_number.fatorial(I)I 
-		imul 
+		isub
+		invokestatic fatorial_fixed_number.fatorial(I)I
+		imul
 		istore 100
 		L7:
 		L2:
 		iload 100
-		ireturn 
+		ireturn
 	}
 	public static main([java/lang/String)V {
 		sipush 5
@@ -54,7 +54,7 @@ public class fatorial_fixed_number {
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		getstatic java/lang/System.out java/io/PrintStream
 		getstatic fatorial_fixed_number.numero I
-		invokestatic fatorial_fixed_number.fatorial(I)I 
+		invokestatic fatorial_fixed_number.fatorial(I)I
 		invokevirtual java/io/PrintStream.print(I)V
 		getstatic java/lang/System.out java/io/PrintStream
 		invokevirtual java/io/PrintStream.println()V

--- a/tests/valid_pascal_programs/fatorial_fixed_number.jasm
+++ b/tests/valid_pascal_programs/fatorial_fixed_number.jasm
@@ -5,10 +5,10 @@ public class fatorial_fixed_number {
 		iload 0
 		sipush 0
 		if_icmpge L4
-		iconst 1 
+		iconst 1
 		goto L5
 		L4:
-		iconst 0 
+		iconst 0
 		L5:
 		ifeq L1
 		sipush 0
@@ -18,10 +18,10 @@ public class fatorial_fixed_number {
 		iload 0
 		sipush 1
 		if_icmpgt L9
-		iconst 1 
+		iconst 1
 		goto L10
 		L9:
-		iconst 0 
+		iconst 0
 		L10:
 		ifeq L6
 		sipush 1

--- a/tests/valid_pascal_programs/for.jasm
+++ b/tests/valid_pascal_programs/for.jasm
@@ -18,7 +18,7 @@ public class for {
 		invokevirtual java/io/PrintStream.println()V
 		getstatic for.i I
 		sipush 1
-		iadd 
+		iadd
 		putstatic for.i I
 		goto L3
 		L2:
@@ -38,7 +38,7 @@ public class for {
 		invokevirtual java/io/PrintStream.println()V
 		getstatic for.i I
 		sipush 1
-		iadd 
+		iadd
 		putstatic for.i I
 		goto L6
 		L5:
@@ -58,7 +58,7 @@ public class for {
 		invokevirtual java/io/PrintStream.println()V
 		getstatic for.i I
 		sipush 1
-		isub 
+		isub
 		putstatic for.i I
 		goto L9
 		L8:

--- a/tests/valid_pascal_programs/for_example.jasm
+++ b/tests/valid_pascal_programs/for_example.jasm
@@ -18,7 +18,7 @@ public class for_example {
 		invokevirtual java/io/PrintStream.println()V
 		getstatic for_example.i I
 		sipush 1
-		iadd 
+		iadd
 		putstatic for_example.i I
 		goto L3
 		L2:

--- a/tests/valid_pascal_programs/function_call_with_one_param_string.jasm
+++ b/tests/valid_pascal_programs/function_call_with_one_param_string.jasm
@@ -4,17 +4,17 @@ public class function_call_with_one_param_string {
 		ldc "Hello "
 		aload 0
 		invokedynamic makeConcatWithConstants(java/lang/String, java/lang/String)java/lang/String {
-			invokestatic java/lang/invoke/StringConcatFactory.makeConcatWithConstants(java/lang/invoke/MethodHandles$Lookup, java/lang/String, java/lang/invoke/MethodType, java/lang/String, [java/lang/Object)java/lang/invoke/CallSite 
-			[""] 
+			invokestatic java/lang/invoke/StringConcatFactory.makeConcatWithConstants(java/lang/invoke/MethodHandles$Lookup, java/lang/String, java/lang/invoke/MethodType, java/lang/String, [java/lang/Object)java/lang/invoke/CallSite
+			[""]
 		}
 		ldc "!"
 		invokedynamic makeConcatWithConstants(java/lang/String, java/lang/String)java/lang/String {
-			invokestatic java/lang/invoke/StringConcatFactory.makeConcatWithConstants(java/lang/invoke/MethodHandles$Lookup, java/lang/String, java/lang/invoke/MethodType, java/lang/String, [java/lang/Object)java/lang/invoke/CallSite 
-			[""] 
+			invokestatic java/lang/invoke/StringConcatFactory.makeConcatWithConstants(java/lang/invoke/MethodHandles$Lookup, java/lang/String, java/lang/invoke/MethodType, java/lang/String, [java/lang/Object)java/lang/invoke/CallSite
+			[""]
 		}
 		astore 100
 		aload 100
-		areturn 
+		areturn
 	}
 	public static main([java/lang/String)V {
 		getstatic java/lang/System.out java/io/PrintStream
@@ -24,7 +24,7 @@ public class function_call_with_one_param_string {
 		invokevirtual java/io/PrintStream.println()V
 		getstatic java/lang/System.out java/io/PrintStream
 		ldc "Alex"
-		invokestatic function_call_with_one_param_string.myfunction(java/lang/String)java/lang/String 
+		invokestatic function_call_with_one_param_string.myfunction(java/lang/String)java/lang/String
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		getstatic java/lang/System.out java/io/PrintStream
 		invokevirtual java/io/PrintStream.println()V

--- a/tests/valid_pascal_programs/function_call_with_two_params.jasm
+++ b/tests/valid_pascal_programs/function_call_with_two_params.jasm
@@ -3,10 +3,10 @@ public class function_call_with_two_params {
 	static addvalues(I, I)I {
 		iload 0
 		iload 1
-		iadd 
+		iadd
 		istore 100
 		iload 100
-		ireturn 
+		ireturn
 	}
 	public static main([java/lang/String)V {
 		getstatic java/lang/System.out java/io/PrintStream
@@ -15,7 +15,7 @@ public class function_call_with_two_params {
 		getstatic java/lang/System.out java/io/PrintStream
 		sipush 2
 		sipush 4
-		invokestatic function_call_with_two_params.addvalues(I, I)I 
+		invokestatic function_call_with_two_params.addvalues(I, I)I
 		invokevirtual java/io/PrintStream.print(I)V
 		getstatic java/lang/System.out java/io/PrintStream
 		invokevirtual java/io/PrintStream.println()V

--- a/tests/valid_pascal_programs/function_call_with_two_params_string.jasm
+++ b/tests/valid_pascal_programs/function_call_with_two_params_string.jasm
@@ -4,22 +4,22 @@ public class function_call_with_two_params_string {
 		aload 0
 		ldc " "
 		invokedynamic makeConcatWithConstants(java/lang/String, java/lang/String)java/lang/String {
-			invokestatic java/lang/invoke/StringConcatFactory.makeConcatWithConstants(java/lang/invoke/MethodHandles$Lookup, java/lang/String, java/lang/invoke/MethodType, java/lang/String, [java/lang/Object)java/lang/invoke/CallSite 
-			[""] 
+			invokestatic java/lang/invoke/StringConcatFactory.makeConcatWithConstants(java/lang/invoke/MethodHandles$Lookup, java/lang/String, java/lang/invoke/MethodType, java/lang/String, [java/lang/Object)java/lang/invoke/CallSite
+			[""]
 		}
 		aload 1
 		invokedynamic makeConcatWithConstants(java/lang/String, java/lang/String)java/lang/String {
-			invokestatic java/lang/invoke/StringConcatFactory.makeConcatWithConstants(java/lang/invoke/MethodHandles$Lookup, java/lang/String, java/lang/invoke/MethodType, java/lang/String, [java/lang/Object)java/lang/invoke/CallSite 
-			[""] 
+			invokestatic java/lang/invoke/StringConcatFactory.makeConcatWithConstants(java/lang/invoke/MethodHandles$Lookup, java/lang/String, java/lang/invoke/MethodType, java/lang/String, [java/lang/Object)java/lang/invoke/CallSite
+			[""]
 		}
 		ldc "!"
 		invokedynamic makeConcatWithConstants(java/lang/String, java/lang/String)java/lang/String {
-			invokestatic java/lang/invoke/StringConcatFactory.makeConcatWithConstants(java/lang/invoke/MethodHandles$Lookup, java/lang/String, java/lang/invoke/MethodType, java/lang/String, [java/lang/Object)java/lang/invoke/CallSite 
-			[""] 
+			invokestatic java/lang/invoke/StringConcatFactory.makeConcatWithConstants(java/lang/invoke/MethodHandles$Lookup, java/lang/String, java/lang/invoke/MethodType, java/lang/String, [java/lang/Object)java/lang/invoke/CallSite
+			[""]
 		}
 		astore 100
 		aload 100
-		areturn 
+		areturn
 	}
 	public static main([java/lang/String)V {
 		getstatic java/lang/System.out java/io/PrintStream
@@ -30,7 +30,7 @@ public class function_call_with_two_params_string {
 		getstatic java/lang/System.out java/io/PrintStream
 		ldc "Hello"
 		ldc "Alex"
-		invokestatic function_call_with_two_params_string.myfunction(java/lang/String, java/lang/String)java/lang/String 
+		invokestatic function_call_with_two_params_string.myfunction(java/lang/String, java/lang/String)java/lang/String
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		getstatic java/lang/System.out java/io/PrintStream
 		invokevirtual java/io/PrintStream.println()V

--- a/tests/valid_pascal_programs/function_call_wo_params.jasm
+++ b/tests/valid_pascal_programs/function_call_wo_params.jasm
@@ -4,7 +4,7 @@ public class function_call_wo_params {
 		ldc "Hello from myfunction!"
 		astore 100
 		aload 100
-		areturn 
+		areturn
 	}
 	public static main([java/lang/String)V {
 		getstatic java/lang/System.out java/io/PrintStream
@@ -13,7 +13,7 @@ public class function_call_wo_params {
 		getstatic java/lang/System.out java/io/PrintStream
 		invokevirtual java/io/PrintStream.println()V
 		getstatic java/lang/System.out java/io/PrintStream
-		invokestatic function_call_wo_params.myfunction()java/lang/String 
+		invokestatic function_call_wo_params.myfunction()java/lang/String
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		getstatic java/lang/System.out java/io/PrintStream
 		invokevirtual java/io/PrintStream.println()V

--- a/tests/valid_pascal_programs/global_and_local_vars_2.jasm
+++ b/tests/valid_pascal_programs/global_and_local_vars_2.jasm
@@ -5,23 +5,23 @@ public class global_and_local_vars_2 {
 	static addvalues(I, I)I {
 		iload 0
 		iload 1
-		iadd 
+		iadd
 		istore 2
 		iload 2
 		getstatic global_and_local_vars_2.addedValue I
-		iadd 
+		iadd
 		istore 3
 		iload 3
 		istore 100
 		iload 100
-		ireturn 
+		ireturn
 	}
 	public static main([java/lang/String)V {
 		sipush 5
 		putstatic global_and_local_vars_2.addedValue I
 		sipush 2
 		sipush 4
-		invokestatic global_and_local_vars_2.addvalues(I, I)I 
+		invokestatic global_and_local_vars_2.addvalues(I, I)I
 		putstatic global_and_local_vars_2.myglobal1 I
 		getstatic java/lang/System.out java/io/PrintStream
 		ldc "addedValue="

--- a/tests/valid_pascal_programs/global_and_local_vars_3.jasm
+++ b/tests/valid_pascal_programs/global_and_local_vars_3.jasm
@@ -6,41 +6,41 @@ public class global_and_local_vars_3 {
 	static addvalues(I, I)I {
 		iload 0
 		iload 1
-		iadd 
+		iadd
 		istore 2
 		iload 2
 		getstatic global_and_local_vars_3.addedValue I
-		iadd 
+		iadd
 		istore 3
 		iload 3
 		istore 100
 		iload 100
-		ireturn 
+		ireturn
 	}
 	static mulvalues(I, I)I {
 		iload 0
 		iload 1
-		imul 
+		imul
 		istore 2
 		iload 2
 		getstatic global_and_local_vars_3.addedValue I
-		iadd 
+		iadd
 		istore 3
 		iload 3
 		istore 100
 		iload 100
-		ireturn 
+		ireturn
 	}
 	public static main([java/lang/String)V {
 		sipush 5
 		putstatic global_and_local_vars_3.addedValue I
 		sipush 2
 		sipush 4
-		invokestatic global_and_local_vars_3.addvalues(I, I)I 
+		invokestatic global_and_local_vars_3.addvalues(I, I)I
 		putstatic global_and_local_vars_3.myglobal1 I
 		sipush 6
 		sipush 8
-		invokestatic global_and_local_vars_3.mulvalues(I, I)I 
+		invokestatic global_and_local_vars_3.mulvalues(I, I)I
 		putstatic global_and_local_vars_3.myglobal2 I
 		getstatic java/lang/System.out java/io/PrintStream
 		ldc "addedValue="

--- a/tests/valid_pascal_programs/global_and_local_vars_4.jasm
+++ b/tests/valid_pascal_programs/global_and_local_vars_4.jasm
@@ -7,61 +7,61 @@ public class global_and_local_vars_4 {
 	static addvalues(I, I)I {
 		iload 0
 		iload 1
-		iadd 
+		iadd
 		istore 2
 		iload 2
 		getstatic global_and_local_vars_4.addedValue I
-		iadd 
+		iadd
 		istore 3
 		iload 3
 		istore 100
 		iload 100
-		ireturn 
+		ireturn
 	}
 	static mulvalues(I, I)I {
 		iload 0
 		iload 1
-		imul 
+		imul
 		istore 2
 		iload 2
 		getstatic global_and_local_vars_4.addedValue I
-		iadd 
+		iadd
 		istore 3
 		iload 3
 		istore 100
 		iload 100
-		ireturn 
+		ireturn
 	}
 	static subvalues(I, I)I {
 		sipush 10
 		istore 4
 		iload 0
 		iload 1
-		isub 
+		isub
 		istore 2
 		iload 2
 		iload 4
-		iadd 
+		iadd
 		istore 3
 		iload 3
 		istore 100
 		iload 100
-		ireturn 
+		ireturn
 	}
 	public static main([java/lang/String)V {
 		sipush 5
 		putstatic global_and_local_vars_4.addedValue I
 		sipush 2
 		sipush 4
-		invokestatic global_and_local_vars_4.addvalues(I, I)I 
+		invokestatic global_and_local_vars_4.addvalues(I, I)I
 		putstatic global_and_local_vars_4.myglobal1 I
 		sipush 6
 		sipush 8
-		invokestatic global_and_local_vars_4.mulvalues(I, I)I 
+		invokestatic global_and_local_vars_4.mulvalues(I, I)I
 		putstatic global_and_local_vars_4.myglobal2 I
 		sipush 8
 		sipush 4
-		invokestatic global_and_local_vars_4.subvalues(I, I)I 
+		invokestatic global_and_local_vars_4.subvalues(I, I)I
 		putstatic global_and_local_vars_4.myglobal3 I
 		getstatic java/lang/System.out java/io/PrintStream
 		ldc "addedValue="

--- a/tests/valid_pascal_programs/if_with_and.jasm
+++ b/tests/valid_pascal_programs/if_with_and.jasm
@@ -4,18 +4,18 @@ public class if_with_and {
 		sipush 111
 		sipush 222
 		if_icmpge L4
-		iconst 1 
+		iconst 1
 		goto L5
 		L4:
-		iconst 0 
+		iconst 0
 		L5:
 		sipush 222
 		sipush 333
 		if_icmpge L6
-		iconst 1 
+		iconst 1
 		goto L7
 		L6:
-		iconst 0 
+		iconst 0
 		L7:
 		iand 
 		ifeq L1

--- a/tests/valid_pascal_programs/if_with_and.jasm
+++ b/tests/valid_pascal_programs/if_with_and.jasm
@@ -17,7 +17,7 @@ public class if_with_and {
 		L6:
 		iconst 0
 		L7:
-		iand 
+		iand
 		ifeq L1
 		getstatic java/lang/System.out java/io/PrintStream
 		ldc "true"

--- a/tests/valid_pascal_programs/if_with_else.jasm
+++ b/tests/valid_pascal_programs/if_with_else.jasm
@@ -4,10 +4,10 @@ public class if_with_else {
 		sipush 111
 		sipush 222
 		if_icmple L4
-		iconst 1 
+		iconst 1
 		goto L5
 		L4:
-		iconst 0 
+		iconst 0
 		L5:
 		ifeq L1
 		getstatic java/lang/System.out java/io/PrintStream

--- a/tests/valid_pascal_programs/if_with_integers_with_and_or.jasm
+++ b/tests/valid_pascal_programs/if_with_integers_with_and_or.jasm
@@ -7,10 +7,10 @@ public class if_with_integers_with_and_or {
 		sipush 2
 		sipush 1
 		if_icmple L4
-		iconst 1 
+		iconst 1
 		goto L5
 		L4:
-		iconst 0 
+		iconst 0
 		L5:
 		ifeq L1
 		getstatic java/lang/System.out java/io/PrintStream
@@ -32,10 +32,10 @@ public class if_with_integers_with_and_or {
 		sipush 1
 		sipush 2
 		if_icmple L9
-		iconst 1 
+		iconst 1
 		goto L10
 		L9:
-		iconst 0 
+		iconst 0
 		L10:
 		ifeq L6
 		getstatic java/lang/System.out java/io/PrintStream
@@ -57,18 +57,18 @@ public class if_with_integers_with_and_or {
 		sipush 111
 		sipush 222
 		if_icmple L14
-		iconst 1 
+		iconst 1
 		goto L15
 		L14:
-		iconst 0 
+		iconst 0
 		L15:
 		sipush 222
 		sipush 333
 		if_icmple L16
-		iconst 1 
+		iconst 1
 		goto L17
 		L16:
-		iconst 0 
+		iconst 0
 		L17:
 		iand 
 		ifeq L11
@@ -91,18 +91,18 @@ public class if_with_integers_with_and_or {
 		sipush 111
 		sipush 222
 		if_icmpge L21
-		iconst 1 
+		iconst 1
 		goto L22
 		L21:
-		iconst 0 
+		iconst 0
 		L22:
 		sipush 222
 		sipush 333
 		if_icmpge L23
-		iconst 1 
+		iconst 1
 		goto L24
 		L23:
-		iconst 0 
+		iconst 0
 		L24:
 		iand 
 		ifeq L18
@@ -125,18 +125,18 @@ public class if_with_integers_with_and_or {
 		sipush 111
 		sipush 222
 		if_icmple L28
-		iconst 1 
+		iconst 1
 		goto L29
 		L28:
-		iconst 0 
+		iconst 0
 		L29:
 		sipush 222
 		sipush 333
 		if_icmpge L30
-		iconst 1 
+		iconst 1
 		goto L31
 		L30:
-		iconst 0 
+		iconst 0
 		L31:
 		iand 
 		ifeq L25
@@ -159,18 +159,18 @@ public class if_with_integers_with_and_or {
 		sipush 111
 		sipush 222
 		if_icmpge L35
-		iconst 1 
+		iconst 1
 		goto L36
 		L35:
-		iconst 0 
+		iconst 0
 		L36:
 		sipush 222
 		sipush 333
 		if_icmple L37
-		iconst 1 
+		iconst 1
 		goto L38
 		L37:
-		iconst 0 
+		iconst 0
 		L38:
 		iand 
 		ifeq L32
@@ -193,18 +193,18 @@ public class if_with_integers_with_and_or {
 		sipush 111
 		sipush 222
 		if_icmple L42
-		iconst 1 
+		iconst 1
 		goto L43
 		L42:
-		iconst 0 
+		iconst 0
 		L43:
 		sipush 222
 		sipush 333
 		if_icmple L44
-		iconst 1 
+		iconst 1
 		goto L45
 		L44:
-		iconst 0 
+		iconst 0
 		L45:
 		ior 
 		ifeq L39
@@ -227,18 +227,18 @@ public class if_with_integers_with_and_or {
 		sipush 111
 		sipush 222
 		if_icmpge L49
-		iconst 1 
+		iconst 1
 		goto L50
 		L49:
-		iconst 0 
+		iconst 0
 		L50:
 		sipush 222
 		sipush 333
 		if_icmpge L51
-		iconst 1 
+		iconst 1
 		goto L52
 		L51:
-		iconst 0 
+		iconst 0
 		L52:
 		ior 
 		ifeq L46
@@ -261,18 +261,18 @@ public class if_with_integers_with_and_or {
 		sipush 111
 		sipush 222
 		if_icmple L56
-		iconst 1 
+		iconst 1
 		goto L57
 		L56:
-		iconst 0 
+		iconst 0
 		L57:
 		sipush 222
 		sipush 333
 		if_icmpge L58
-		iconst 1 
+		iconst 1
 		goto L59
 		L58:
-		iconst 0 
+		iconst 0
 		L59:
 		ior 
 		ifeq L53
@@ -295,18 +295,18 @@ public class if_with_integers_with_and_or {
 		sipush 111
 		sipush 222
 		if_icmpge L63
-		iconst 1 
+		iconst 1
 		goto L64
 		L63:
-		iconst 0 
+		iconst 0
 		L64:
 		sipush 222
 		sipush 333
 		if_icmple L65
-		iconst 1 
+		iconst 1
 		goto L66
 		L65:
-		iconst 0 
+		iconst 0
 		L66:
 		ior 
 		ifeq L60

--- a/tests/valid_pascal_programs/if_with_integers_with_and_or.jasm
+++ b/tests/valid_pascal_programs/if_with_integers_with_and_or.jasm
@@ -70,7 +70,7 @@ public class if_with_integers_with_and_or {
 		L16:
 		iconst 0
 		L17:
-		iand 
+		iand
 		ifeq L11
 		getstatic java/lang/System.out java/io/PrintStream
 		ldc "true"
@@ -104,7 +104,7 @@ public class if_with_integers_with_and_or {
 		L23:
 		iconst 0
 		L24:
-		iand 
+		iand
 		ifeq L18
 		getstatic java/lang/System.out java/io/PrintStream
 		ldc "true"
@@ -138,7 +138,7 @@ public class if_with_integers_with_and_or {
 		L30:
 		iconst 0
 		L31:
-		iand 
+		iand
 		ifeq L25
 		getstatic java/lang/System.out java/io/PrintStream
 		ldc "true"
@@ -172,7 +172,7 @@ public class if_with_integers_with_and_or {
 		L37:
 		iconst 0
 		L38:
-		iand 
+		iand
 		ifeq L32
 		getstatic java/lang/System.out java/io/PrintStream
 		ldc "true"
@@ -206,7 +206,7 @@ public class if_with_integers_with_and_or {
 		L44:
 		iconst 0
 		L45:
-		ior 
+		ior
 		ifeq L39
 		getstatic java/lang/System.out java/io/PrintStream
 		ldc "true"
@@ -240,7 +240,7 @@ public class if_with_integers_with_and_or {
 		L51:
 		iconst 0
 		L52:
-		ior 
+		ior
 		ifeq L46
 		getstatic java/lang/System.out java/io/PrintStream
 		ldc "true"
@@ -274,7 +274,7 @@ public class if_with_integers_with_and_or {
 		L58:
 		iconst 0
 		L59:
-		ior 
+		ior
 		ifeq L53
 		getstatic java/lang/System.out java/io/PrintStream
 		ldc "true"
@@ -308,7 +308,7 @@ public class if_with_integers_with_and_or {
 		L65:
 		iconst 0
 		L66:
-		ior 
+		ior
 		ifeq L60
 		getstatic java/lang/System.out java/io/PrintStream
 		ldc "true"

--- a/tests/valid_pascal_programs/if_with_integers_with_not.jasm
+++ b/tests/valid_pascal_programs/if_with_integers_with_not.jasm
@@ -7,16 +7,16 @@ public class if_with_integers_with_not {
 		sipush 111
 		sipush 222
 		if_icmple L4
-		iconst 1 
+		iconst 1
 		goto L5
 		L4:
-		iconst 0 
+		iconst 0
 		L5:
 		ifne L6
-		iconst 1 
+		iconst 1
 		goto L7
 		L6:
-		iconst 0 
+		iconst 0
 		L7:
 		ifeq L1
 		getstatic java/lang/System.out java/io/PrintStream
@@ -38,25 +38,25 @@ public class if_with_integers_with_not {
 		sipush 111
 		sipush 222
 		if_icmple L11
-		iconst 1 
+		iconst 1
 		goto L12
 		L11:
-		iconst 0 
+		iconst 0
 		L12:
 		sipush 222
 		sipush 333
 		if_icmple L13
-		iconst 1 
+		iconst 1
 		goto L14
 		L13:
-		iconst 0 
+		iconst 0
 		L14:
 		iand 
 		ifne L15
-		iconst 1 
+		iconst 1
 		goto L16
 		L15:
-		iconst 0 
+		iconst 0
 		L16:
 		ifeq L8
 		getstatic java/lang/System.out java/io/PrintStream
@@ -78,25 +78,25 @@ public class if_with_integers_with_not {
 		sipush 111
 		sipush 222
 		if_icmpge L20
-		iconst 1 
+		iconst 1
 		goto L21
 		L20:
-		iconst 0 
+		iconst 0
 		L21:
 		sipush 222
 		sipush 333
 		if_icmpge L22
-		iconst 1 
+		iconst 1
 		goto L23
 		L22:
-		iconst 0 
+		iconst 0
 		L23:
 		iand 
 		ifne L24
-		iconst 1 
+		iconst 1
 		goto L25
 		L24:
-		iconst 0 
+		iconst 0
 		L25:
 		ifeq L17
 		getstatic java/lang/System.out java/io/PrintStream
@@ -118,25 +118,25 @@ public class if_with_integers_with_not {
 		sipush 111
 		sipush 222
 		if_icmple L29
-		iconst 1 
+		iconst 1
 		goto L30
 		L29:
-		iconst 0 
+		iconst 0
 		L30:
 		sipush 222
 		sipush 333
 		if_icmpge L31
-		iconst 1 
+		iconst 1
 		goto L32
 		L31:
-		iconst 0 
+		iconst 0
 		L32:
 		iand 
 		ifne L33
-		iconst 1 
+		iconst 1
 		goto L34
 		L33:
-		iconst 0 
+		iconst 0
 		L34:
 		ifeq L26
 		getstatic java/lang/System.out java/io/PrintStream
@@ -158,25 +158,25 @@ public class if_with_integers_with_not {
 		sipush 111
 		sipush 222
 		if_icmpge L38
-		iconst 1 
+		iconst 1
 		goto L39
 		L38:
-		iconst 0 
+		iconst 0
 		L39:
 		sipush 222
 		sipush 333
 		if_icmple L40
-		iconst 1 
+		iconst 1
 		goto L41
 		L40:
-		iconst 0 
+		iconst 0
 		L41:
 		iand 
 		ifne L42
-		iconst 1 
+		iconst 1
 		goto L43
 		L42:
-		iconst 0 
+		iconst 0
 		L43:
 		ifeq L35
 		getstatic java/lang/System.out java/io/PrintStream
@@ -198,25 +198,25 @@ public class if_with_integers_with_not {
 		sipush 111
 		sipush 222
 		if_icmple L47
-		iconst 1 
+		iconst 1
 		goto L48
 		L47:
-		iconst 0 
+		iconst 0
 		L48:
 		sipush 222
 		sipush 333
 		if_icmple L49
-		iconst 1 
+		iconst 1
 		goto L50
 		L49:
-		iconst 0 
+		iconst 0
 		L50:
 		ior 
 		ifne L51
-		iconst 1 
+		iconst 1
 		goto L52
 		L51:
-		iconst 0 
+		iconst 0
 		L52:
 		ifeq L44
 		getstatic java/lang/System.out java/io/PrintStream
@@ -238,25 +238,25 @@ public class if_with_integers_with_not {
 		sipush 111
 		sipush 222
 		if_icmpge L56
-		iconst 1 
+		iconst 1
 		goto L57
 		L56:
-		iconst 0 
+		iconst 0
 		L57:
 		sipush 222
 		sipush 333
 		if_icmpge L58
-		iconst 1 
+		iconst 1
 		goto L59
 		L58:
-		iconst 0 
+		iconst 0
 		L59:
 		ior 
 		ifne L60
-		iconst 1 
+		iconst 1
 		goto L61
 		L60:
-		iconst 0 
+		iconst 0
 		L61:
 		ifeq L53
 		getstatic java/lang/System.out java/io/PrintStream
@@ -278,25 +278,25 @@ public class if_with_integers_with_not {
 		sipush 111
 		sipush 222
 		if_icmple L65
-		iconst 1 
+		iconst 1
 		goto L66
 		L65:
-		iconst 0 
+		iconst 0
 		L66:
 		sipush 222
 		sipush 333
 		if_icmpge L67
-		iconst 1 
+		iconst 1
 		goto L68
 		L67:
-		iconst 0 
+		iconst 0
 		L68:
 		ior 
 		ifne L69
-		iconst 1 
+		iconst 1
 		goto L70
 		L69:
-		iconst 0 
+		iconst 0
 		L70:
 		ifeq L62
 		getstatic java/lang/System.out java/io/PrintStream
@@ -318,25 +318,25 @@ public class if_with_integers_with_not {
 		sipush 111
 		sipush 222
 		if_icmpge L74
-		iconst 1 
+		iconst 1
 		goto L75
 		L74:
-		iconst 0 
+		iconst 0
 		L75:
 		sipush 222
 		sipush 333
 		if_icmple L76
-		iconst 1 
+		iconst 1
 		goto L77
 		L76:
-		iconst 0 
+		iconst 0
 		L77:
 		ior 
 		ifne L78
-		iconst 1 
+		iconst 1
 		goto L79
 		L78:
-		iconst 0 
+		iconst 0
 		L79:
 		ifeq L71
 		getstatic java/lang/System.out java/io/PrintStream
@@ -358,24 +358,24 @@ public class if_with_integers_with_not {
 		sipush 111
 		sipush 222
 		if_icmpge L83
-		iconst 1 
+		iconst 1
 		goto L84
 		L83:
-		iconst 0 
+		iconst 0
 		L84:
 		sipush 222
 		sipush 333
 		if_icmple L85
-		iconst 1 
+		iconst 1
 		goto L86
 		L85:
-		iconst 0 
+		iconst 0
 		L86:
 		ifne L87
-		iconst 1 
+		iconst 1
 		goto L88
 		L87:
-		iconst 0 
+		iconst 0
 		L88:
 		iand 
 		ifeq L80

--- a/tests/valid_pascal_programs/if_with_integers_with_not.jasm
+++ b/tests/valid_pascal_programs/if_with_integers_with_not.jasm
@@ -51,7 +51,7 @@ public class if_with_integers_with_not {
 		L13:
 		iconst 0
 		L14:
-		iand 
+		iand
 		ifne L15
 		iconst 1
 		goto L16
@@ -91,7 +91,7 @@ public class if_with_integers_with_not {
 		L22:
 		iconst 0
 		L23:
-		iand 
+		iand
 		ifne L24
 		iconst 1
 		goto L25
@@ -131,7 +131,7 @@ public class if_with_integers_with_not {
 		L31:
 		iconst 0
 		L32:
-		iand 
+		iand
 		ifne L33
 		iconst 1
 		goto L34
@@ -171,7 +171,7 @@ public class if_with_integers_with_not {
 		L40:
 		iconst 0
 		L41:
-		iand 
+		iand
 		ifne L42
 		iconst 1
 		goto L43
@@ -211,7 +211,7 @@ public class if_with_integers_with_not {
 		L49:
 		iconst 0
 		L50:
-		ior 
+		ior
 		ifne L51
 		iconst 1
 		goto L52
@@ -251,7 +251,7 @@ public class if_with_integers_with_not {
 		L58:
 		iconst 0
 		L59:
-		ior 
+		ior
 		ifne L60
 		iconst 1
 		goto L61
@@ -291,7 +291,7 @@ public class if_with_integers_with_not {
 		L67:
 		iconst 0
 		L68:
-		ior 
+		ior
 		ifne L69
 		iconst 1
 		goto L70
@@ -331,7 +331,7 @@ public class if_with_integers_with_not {
 		L76:
 		iconst 0
 		L77:
-		ior 
+		ior
 		ifne L78
 		iconst 1
 		goto L79
@@ -377,7 +377,7 @@ public class if_with_integers_with_not {
 		L87:
 		iconst 0
 		L88:
-		iand 
+		iand
 		ifeq L80
 		getstatic java/lang/System.out java/io/PrintStream
 		ldc "true"

--- a/tests/valid_pascal_programs/if_with_integers_without_and_or.jasm
+++ b/tests/valid_pascal_programs/if_with_integers_without_and_or.jasm
@@ -7,10 +7,10 @@ public class if_with_integers_without_and_or {
 		sipush 111
 		sipush 222
 		if_icmple L4
-		iconst 1 
+		iconst 1
 		goto L5
 		L4:
-		iconst 0 
+		iconst 0
 		L5:
 		ifeq L1
 		getstatic java/lang/System.out java/io/PrintStream
@@ -32,10 +32,10 @@ public class if_with_integers_without_and_or {
 		sipush 333
 		sipush 222
 		if_icmple L9
-		iconst 1 
+		iconst 1
 		goto L10
 		L9:
-		iconst 0 
+		iconst 0
 		L10:
 		ifeq L6
 		getstatic java/lang/System.out java/io/PrintStream
@@ -59,10 +59,10 @@ public class if_with_integers_without_and_or {
 		sipush 2
 		sipush 4
 		if_icmple L14
-		iconst 1 
+		iconst 1
 		goto L15
 		L14:
-		iconst 0 
+		iconst 0
 		L15:
 		ifeq L11
 		getstatic java/lang/System.out java/io/PrintStream
@@ -79,10 +79,10 @@ public class if_with_integers_without_and_or {
 		sipush 4
 		sipush 2
 		if_icmple L19
-		iconst 1 
+		iconst 1
 		goto L20
 		L19:
-		iconst 0 
+		iconst 0
 		L20:
 		ifeq L16
 		getstatic java/lang/System.out java/io/PrintStream
@@ -99,10 +99,10 @@ public class if_with_integers_without_and_or {
 		sipush 111
 		sipush 222
 		if_icmpge L24
-		iconst 1 
+		iconst 1
 		goto L25
 		L24:
-		iconst 0 
+		iconst 0
 		L25:
 		ifeq L21
 		getstatic java/lang/System.out java/io/PrintStream
@@ -124,10 +124,10 @@ public class if_with_integers_without_and_or {
 		sipush 222
 		sipush 111
 		if_icmpge L29
-		iconst 1 
+		iconst 1
 		goto L30
 		L29:
-		iconst 0 
+		iconst 0
 		L30:
 		ifeq L26
 		getstatic java/lang/System.out java/io/PrintStream
@@ -149,10 +149,10 @@ public class if_with_integers_without_and_or {
 		sipush 222
 		sipush 111
 		if_icmplt L34
-		iconst 1 
+		iconst 1
 		goto L35
 		L34:
-		iconst 0 
+		iconst 0
 		L35:
 		ifeq L31
 		getstatic java/lang/System.out java/io/PrintStream
@@ -174,10 +174,10 @@ public class if_with_integers_without_and_or {
 		sipush 111
 		sipush 222
 		if_icmplt L39
-		iconst 1 
+		iconst 1
 		goto L40
 		L39:
-		iconst 0 
+		iconst 0
 		L40:
 		ifeq L36
 		getstatic java/lang/System.out java/io/PrintStream
@@ -199,10 +199,10 @@ public class if_with_integers_without_and_or {
 		sipush 111
 		sipush 111
 		if_icmplt L44
-		iconst 1 
+		iconst 1
 		goto L45
 		L44:
-		iconst 0 
+		iconst 0
 		L45:
 		ifeq L41
 		getstatic java/lang/System.out java/io/PrintStream
@@ -224,10 +224,10 @@ public class if_with_integers_without_and_or {
 		sipush 111
 		sipush 222
 		if_icmpgt L49
-		iconst 1 
+		iconst 1
 		goto L50
 		L49:
-		iconst 0 
+		iconst 0
 		L50:
 		ifeq L46
 		getstatic java/lang/System.out java/io/PrintStream
@@ -249,10 +249,10 @@ public class if_with_integers_without_and_or {
 		sipush 222
 		sipush 111
 		if_icmpgt L54
-		iconst 1 
+		iconst 1
 		goto L55
 		L54:
-		iconst 0 
+		iconst 0
 		L55:
 		ifeq L51
 		getstatic java/lang/System.out java/io/PrintStream
@@ -274,10 +274,10 @@ public class if_with_integers_without_and_or {
 		sipush 111
 		sipush 111
 		if_icmpgt L59
-		iconst 1 
+		iconst 1
 		goto L60
 		L59:
-		iconst 0 
+		iconst 0
 		L60:
 		ifeq L56
 		getstatic java/lang/System.out java/io/PrintStream
@@ -299,10 +299,10 @@ public class if_with_integers_without_and_or {
 		sipush 222
 		sipush 222
 		if_icmpne L64
-		iconst 1 
+		iconst 1
 		goto L65
 		L64:
-		iconst 0 
+		iconst 0
 		L65:
 		ifeq L61
 		getstatic java/lang/System.out java/io/PrintStream
@@ -324,10 +324,10 @@ public class if_with_integers_without_and_or {
 		sipush 111
 		sipush 222
 		if_icmpne L69
-		iconst 1 
+		iconst 1
 		goto L70
 		L69:
-		iconst 0 
+		iconst 0
 		L70:
 		ifeq L66
 		getstatic java/lang/System.out java/io/PrintStream
@@ -349,10 +349,10 @@ public class if_with_integers_without_and_or {
 		sipush 111
 		sipush 222
 		if_icmpeq L74
-		iconst 1 
+		iconst 1
 		goto L75
 		L74:
-		iconst 0 
+		iconst 0
 		L75:
 		ifeq L71
 		getstatic java/lang/System.out java/io/PrintStream
@@ -374,10 +374,10 @@ public class if_with_integers_without_and_or {
 		sipush 111
 		sipush 111
 		if_icmpeq L79
-		iconst 1 
+		iconst 1
 		goto L80
 		L79:
-		iconst 0 
+		iconst 0
 		L80:
 		ifeq L76
 		getstatic java/lang/System.out java/io/PrintStream

--- a/tests/valid_pascal_programs/if_with_not.jasm
+++ b/tests/valid_pascal_programs/if_with_not.jasm
@@ -4,16 +4,16 @@ public class if_with_not {
 		sipush 111
 		sipush 222
 		if_icmpge L4
-		iconst 1 
+		iconst 1
 		goto L5
 		L4:
-		iconst 0 
+		iconst 0
 		L5:
 		ifne L6
-		iconst 1 
+		iconst 1
 		goto L7
 		L6:
-		iconst 0 
+		iconst 0
 		L7:
 		ifeq L1
 		getstatic java/lang/System.out java/io/PrintStream

--- a/tests/valid_pascal_programs/if_with_or.jasm
+++ b/tests/valid_pascal_programs/if_with_or.jasm
@@ -17,7 +17,7 @@ public class if_with_or {
 		L6:
 		iconst 0
 		L7:
-		ior 
+		ior
 		ifeq L1
 		getstatic java/lang/System.out java/io/PrintStream
 		ldc "true"

--- a/tests/valid_pascal_programs/if_with_or.jasm
+++ b/tests/valid_pascal_programs/if_with_or.jasm
@@ -4,18 +4,18 @@ public class if_with_or {
 		sipush 111
 		sipush 222
 		if_icmpge L4
-		iconst 1 
+		iconst 1
 		goto L5
 		L4:
-		iconst 0 
+		iconst 0
 		L5:
 		sipush 222
 		sipush 333
 		if_icmpge L6
-		iconst 1 
+		iconst 1
 		goto L7
 		L6:
-		iconst 0 
+		iconst 0
 		L7:
 		ior 
 		ifeq L1

--- a/tests/valid_pascal_programs/if_with_strings_with_and_or.jasm
+++ b/tests/valid_pascal_programs/if_with_strings_with_and_or.jasm
@@ -74,7 +74,7 @@ public class if_with_strings_with_and_or {
 		L16:
 		iconst 0
 		L17:
-		iand 
+		iand
 		ifeq L11
 		getstatic java/lang/System.out java/io/PrintStream
 		ldc "true"
@@ -110,7 +110,7 @@ public class if_with_strings_with_and_or {
 		L23:
 		iconst 0
 		L24:
-		iand 
+		iand
 		ifeq L18
 		getstatic java/lang/System.out java/io/PrintStream
 		ldc "true"
@@ -146,7 +146,7 @@ public class if_with_strings_with_and_or {
 		L30:
 		iconst 0
 		L31:
-		iand 
+		iand
 		ifeq L25
 		getstatic java/lang/System.out java/io/PrintStream
 		ldc "true"
@@ -182,7 +182,7 @@ public class if_with_strings_with_and_or {
 		L37:
 		iconst 0
 		L38:
-		iand 
+		iand
 		ifeq L32
 		getstatic java/lang/System.out java/io/PrintStream
 		ldc "true"
@@ -218,7 +218,7 @@ public class if_with_strings_with_and_or {
 		L44:
 		iconst 0
 		L45:
-		ior 
+		ior
 		ifeq L39
 		getstatic java/lang/System.out java/io/PrintStream
 		ldc "true"
@@ -254,7 +254,7 @@ public class if_with_strings_with_and_or {
 		L51:
 		iconst 0
 		L52:
-		ior 
+		ior
 		ifeq L46
 		getstatic java/lang/System.out java/io/PrintStream
 		ldc "true"
@@ -290,7 +290,7 @@ public class if_with_strings_with_and_or {
 		L58:
 		iconst 0
 		L59:
-		ior 
+		ior
 		ifeq L53
 		getstatic java/lang/System.out java/io/PrintStream
 		ldc "true"
@@ -326,7 +326,7 @@ public class if_with_strings_with_and_or {
 		L65:
 		iconst 0
 		L66:
-		ior 
+		ior
 		ifeq L60
 		getstatic java/lang/System.out java/io/PrintStream
 		ldc "true"

--- a/tests/valid_pascal_programs/if_with_strings_with_and_or.jasm
+++ b/tests/valid_pascal_programs/if_with_strings_with_and_or.jasm
@@ -8,10 +8,10 @@ public class if_with_strings_with_and_or {
 		ldc "a"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		iflt L4
-		iconst 1 
+		iconst 1
 		goto L5
 		L4:
-		iconst 0 
+		iconst 0
 		L5:
 		ifeq L1
 		getstatic java/lang/System.out java/io/PrintStream
@@ -34,10 +34,10 @@ public class if_with_strings_with_and_or {
 		ldc "b"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		iflt L9
-		iconst 1 
+		iconst 1
 		goto L10
 		L9:
-		iconst 0 
+		iconst 0
 		L10:
 		ifeq L6
 		getstatic java/lang/System.out java/io/PrintStream
@@ -60,19 +60,19 @@ public class if_with_strings_with_and_or {
 		ldc "bbb"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		iflt L14
-		iconst 1 
+		iconst 1
 		goto L15
 		L14:
-		iconst 0 
+		iconst 0
 		L15:
 		ldc "bbb"
 		ldc "ccc"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		iflt L16
-		iconst 1 
+		iconst 1
 		goto L17
 		L16:
-		iconst 0 
+		iconst 0
 		L17:
 		iand 
 		ifeq L11
@@ -96,19 +96,19 @@ public class if_with_strings_with_and_or {
 		ldc "bbb"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		ifgt L21
-		iconst 1 
+		iconst 1
 		goto L22
 		L21:
-		iconst 0 
+		iconst 0
 		L22:
 		ldc "bbb"
 		ldc "ccc"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		ifgt L23
-		iconst 1 
+		iconst 1
 		goto L24
 		L23:
-		iconst 0 
+		iconst 0
 		L24:
 		iand 
 		ifeq L18
@@ -132,19 +132,19 @@ public class if_with_strings_with_and_or {
 		ldc "bbb"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		iflt L28
-		iconst 1 
+		iconst 1
 		goto L29
 		L28:
-		iconst 0 
+		iconst 0
 		L29:
 		ldc "bbb"
 		ldc "ccc"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		ifgt L30
-		iconst 1 
+		iconst 1
 		goto L31
 		L30:
-		iconst 0 
+		iconst 0
 		L31:
 		iand 
 		ifeq L25
@@ -168,19 +168,19 @@ public class if_with_strings_with_and_or {
 		ldc "bbb"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		ifgt L35
-		iconst 1 
+		iconst 1
 		goto L36
 		L35:
-		iconst 0 
+		iconst 0
 		L36:
 		ldc "bbb"
 		ldc "ccc"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		iflt L37
-		iconst 1 
+		iconst 1
 		goto L38
 		L37:
-		iconst 0 
+		iconst 0
 		L38:
 		iand 
 		ifeq L32
@@ -204,19 +204,19 @@ public class if_with_strings_with_and_or {
 		ldc "bbb"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		iflt L42
-		iconst 1 
+		iconst 1
 		goto L43
 		L42:
-		iconst 0 
+		iconst 0
 		L43:
 		ldc "bbb"
 		ldc "ccc"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		iflt L44
-		iconst 1 
+		iconst 1
 		goto L45
 		L44:
-		iconst 0 
+		iconst 0
 		L45:
 		ior 
 		ifeq L39
@@ -240,19 +240,19 @@ public class if_with_strings_with_and_or {
 		ldc "bbb"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		ifgt L49
-		iconst 1 
+		iconst 1
 		goto L50
 		L49:
-		iconst 0 
+		iconst 0
 		L50:
 		ldc "bbb"
 		ldc "ccc"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		ifgt L51
-		iconst 1 
+		iconst 1
 		goto L52
 		L51:
-		iconst 0 
+		iconst 0
 		L52:
 		ior 
 		ifeq L46
@@ -276,19 +276,19 @@ public class if_with_strings_with_and_or {
 		ldc "bbb"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		iflt L56
-		iconst 1 
+		iconst 1
 		goto L57
 		L56:
-		iconst 0 
+		iconst 0
 		L57:
 		ldc "bbb"
 		ldc "ccc"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		ifgt L58
-		iconst 1 
+		iconst 1
 		goto L59
 		L58:
-		iconst 0 
+		iconst 0
 		L59:
 		ior 
 		ifeq L53
@@ -312,19 +312,19 @@ public class if_with_strings_with_and_or {
 		ldc "bbb"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		ifgt L63
-		iconst 1 
+		iconst 1
 		goto L64
 		L63:
-		iconst 0 
+		iconst 0
 		L64:
 		ldc "bbb"
 		ldc "ccc"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		iflt L65
-		iconst 1 
+		iconst 1
 		goto L66
 		L65:
-		iconst 0 
+		iconst 0
 		L66:
 		ior 
 		ifeq L60

--- a/tests/valid_pascal_programs/if_with_strings_with_not.jasm
+++ b/tests/valid_pascal_programs/if_with_strings_with_not.jasm
@@ -54,7 +54,7 @@ public class if_with_strings_with_not {
 		L13:
 		iconst 0
 		L14:
-		iand 
+		iand
 		ifne L15
 		iconst 1
 		goto L16
@@ -96,7 +96,7 @@ public class if_with_strings_with_not {
 		L22:
 		iconst 0
 		L23:
-		iand 
+		iand
 		ifne L24
 		iconst 1
 		goto L25
@@ -138,7 +138,7 @@ public class if_with_strings_with_not {
 		L31:
 		iconst 0
 		L32:
-		iand 
+		iand
 		ifne L33
 		iconst 1
 		goto L34
@@ -180,7 +180,7 @@ public class if_with_strings_with_not {
 		L40:
 		iconst 0
 		L41:
-		iand 
+		iand
 		ifne L42
 		iconst 1
 		goto L43
@@ -222,7 +222,7 @@ public class if_with_strings_with_not {
 		L49:
 		iconst 0
 		L50:
-		ior 
+		ior
 		ifne L51
 		iconst 1
 		goto L52
@@ -264,7 +264,7 @@ public class if_with_strings_with_not {
 		L58:
 		iconst 0
 		L59:
-		ior 
+		ior
 		ifne L60
 		iconst 1
 		goto L61
@@ -306,7 +306,7 @@ public class if_with_strings_with_not {
 		L67:
 		iconst 0
 		L68:
-		ior 
+		ior
 		ifne L69
 		iconst 1
 		goto L70
@@ -348,7 +348,7 @@ public class if_with_strings_with_not {
 		L76:
 		iconst 0
 		L77:
-		ior 
+		ior
 		ifne L78
 		iconst 1
 		goto L79
@@ -396,7 +396,7 @@ public class if_with_strings_with_not {
 		L87:
 		iconst 0
 		L88:
-		iand 
+		iand
 		ifeq L80
 		getstatic java/lang/System.out java/io/PrintStream
 		ldc "true"

--- a/tests/valid_pascal_programs/if_with_strings_with_not.jasm
+++ b/tests/valid_pascal_programs/if_with_strings_with_not.jasm
@@ -8,16 +8,16 @@ public class if_with_strings_with_not {
 		ldc "bbb"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		iflt L4
-		iconst 1 
+		iconst 1
 		goto L5
 		L4:
-		iconst 0 
+		iconst 0
 		L5:
 		ifne L6
-		iconst 1 
+		iconst 1
 		goto L7
 		L6:
-		iconst 0 
+		iconst 0
 		L7:
 		ifeq L1
 		getstatic java/lang/System.out java/io/PrintStream
@@ -40,26 +40,26 @@ public class if_with_strings_with_not {
 		ldc "bbb"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		iflt L11
-		iconst 1 
+		iconst 1
 		goto L12
 		L11:
-		iconst 0 
+		iconst 0
 		L12:
 		ldc "bbb"
 		ldc "ccc"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		iflt L13
-		iconst 1 
+		iconst 1
 		goto L14
 		L13:
-		iconst 0 
+		iconst 0
 		L14:
 		iand 
 		ifne L15
-		iconst 1 
+		iconst 1
 		goto L16
 		L15:
-		iconst 0 
+		iconst 0
 		L16:
 		ifeq L8
 		getstatic java/lang/System.out java/io/PrintStream
@@ -82,26 +82,26 @@ public class if_with_strings_with_not {
 		ldc "bbb"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		ifgt L20
-		iconst 1 
+		iconst 1
 		goto L21
 		L20:
-		iconst 0 
+		iconst 0
 		L21:
 		ldc "bbb"
 		ldc "ccc"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		ifgt L22
-		iconst 1 
+		iconst 1
 		goto L23
 		L22:
-		iconst 0 
+		iconst 0
 		L23:
 		iand 
 		ifne L24
-		iconst 1 
+		iconst 1
 		goto L25
 		L24:
-		iconst 0 
+		iconst 0
 		L25:
 		ifeq L17
 		getstatic java/lang/System.out java/io/PrintStream
@@ -124,26 +124,26 @@ public class if_with_strings_with_not {
 		ldc "bbb"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		iflt L29
-		iconst 1 
+		iconst 1
 		goto L30
 		L29:
-		iconst 0 
+		iconst 0
 		L30:
 		ldc "bbb"
 		ldc "ccc"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		ifgt L31
-		iconst 1 
+		iconst 1
 		goto L32
 		L31:
-		iconst 0 
+		iconst 0
 		L32:
 		iand 
 		ifne L33
-		iconst 1 
+		iconst 1
 		goto L34
 		L33:
-		iconst 0 
+		iconst 0
 		L34:
 		ifeq L26
 		getstatic java/lang/System.out java/io/PrintStream
@@ -166,26 +166,26 @@ public class if_with_strings_with_not {
 		ldc "bbb"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		ifgt L38
-		iconst 1 
+		iconst 1
 		goto L39
 		L38:
-		iconst 0 
+		iconst 0
 		L39:
 		ldc "bbb"
 		ldc "ccc"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		iflt L40
-		iconst 1 
+		iconst 1
 		goto L41
 		L40:
-		iconst 0 
+		iconst 0
 		L41:
 		iand 
 		ifne L42
-		iconst 1 
+		iconst 1
 		goto L43
 		L42:
-		iconst 0 
+		iconst 0
 		L43:
 		ifeq L35
 		getstatic java/lang/System.out java/io/PrintStream
@@ -208,26 +208,26 @@ public class if_with_strings_with_not {
 		ldc "bbb"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		iflt L47
-		iconst 1 
+		iconst 1
 		goto L48
 		L47:
-		iconst 0 
+		iconst 0
 		L48:
 		ldc "bbb"
 		ldc "ccc"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		iflt L49
-		iconst 1 
+		iconst 1
 		goto L50
 		L49:
-		iconst 0 
+		iconst 0
 		L50:
 		ior 
 		ifne L51
-		iconst 1 
+		iconst 1
 		goto L52
 		L51:
-		iconst 0 
+		iconst 0
 		L52:
 		ifeq L44
 		getstatic java/lang/System.out java/io/PrintStream
@@ -250,26 +250,26 @@ public class if_with_strings_with_not {
 		ldc "bbb"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		ifgt L56
-		iconst 1 
+		iconst 1
 		goto L57
 		L56:
-		iconst 0 
+		iconst 0
 		L57:
 		ldc "bbb"
 		ldc "ccc"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		ifgt L58
-		iconst 1 
+		iconst 1
 		goto L59
 		L58:
-		iconst 0 
+		iconst 0
 		L59:
 		ior 
 		ifne L60
-		iconst 1 
+		iconst 1
 		goto L61
 		L60:
-		iconst 0 
+		iconst 0
 		L61:
 		ifeq L53
 		getstatic java/lang/System.out java/io/PrintStream
@@ -292,26 +292,26 @@ public class if_with_strings_with_not {
 		ldc "bbb"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		iflt L65
-		iconst 1 
+		iconst 1
 		goto L66
 		L65:
-		iconst 0 
+		iconst 0
 		L66:
 		ldc "bbb"
 		ldc "ccc"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		ifgt L67
-		iconst 1 
+		iconst 1
 		goto L68
 		L67:
-		iconst 0 
+		iconst 0
 		L68:
 		ior 
 		ifne L69
-		iconst 1 
+		iconst 1
 		goto L70
 		L69:
-		iconst 0 
+		iconst 0
 		L70:
 		ifeq L62
 		getstatic java/lang/System.out java/io/PrintStream
@@ -334,26 +334,26 @@ public class if_with_strings_with_not {
 		ldc "bbb"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		ifgt L74
-		iconst 1 
+		iconst 1
 		goto L75
 		L74:
-		iconst 0 
+		iconst 0
 		L75:
 		ldc "bbb"
 		ldc "ccc"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		iflt L76
-		iconst 1 
+		iconst 1
 		goto L77
 		L76:
-		iconst 0 
+		iconst 0
 		L77:
 		ior 
 		ifne L78
-		iconst 1 
+		iconst 1
 		goto L79
 		L78:
-		iconst 0 
+		iconst 0
 		L79:
 		ifeq L71
 		getstatic java/lang/System.out java/io/PrintStream
@@ -376,25 +376,25 @@ public class if_with_strings_with_not {
 		ldc "bbb"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		ifgt L83
-		iconst 1 
+		iconst 1
 		goto L84
 		L83:
-		iconst 0 
+		iconst 0
 		L84:
 		ldc "bbb"
 		ldc "ccc"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		iflt L85
-		iconst 1 
+		iconst 1
 		goto L86
 		L85:
-		iconst 0 
+		iconst 0
 		L86:
 		ifne L87
-		iconst 1 
+		iconst 1
 		goto L88
 		L87:
-		iconst 0 
+		iconst 0
 		L88:
 		iand 
 		ifeq L80

--- a/tests/valid_pascal_programs/if_with_strings_without_and_or.jasm
+++ b/tests/valid_pascal_programs/if_with_strings_without_and_or.jasm
@@ -8,10 +8,10 @@ public class if_with_strings_without_and_or {
 		ldc "bbb"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		iflt L4
-		iconst 1 
+		iconst 1
 		goto L5
 		L4:
-		iconst 0 
+		iconst 0
 		L5:
 		ifeq L1
 		getstatic java/lang/System.out java/io/PrintStream
@@ -34,10 +34,10 @@ public class if_with_strings_without_and_or {
 		ldc "bbb"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		iflt L9
-		iconst 1 
+		iconst 1
 		goto L10
 		L9:
-		iconst 0 
+		iconst 0
 		L10:
 		ifeq L6
 		getstatic java/lang/System.out java/io/PrintStream
@@ -62,10 +62,10 @@ public class if_with_strings_without_and_or {
 		ldc "d"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		iflt L14
-		iconst 1 
+		iconst 1
 		goto L15
 		L14:
-		iconst 0 
+		iconst 0
 		L15:
 		ifeq L11
 		getstatic java/lang/System.out java/io/PrintStream
@@ -83,10 +83,10 @@ public class if_with_strings_without_and_or {
 		ldc "b"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		iflt L19
-		iconst 1 
+		iconst 1
 		goto L20
 		L19:
-		iconst 0 
+		iconst 0
 		L20:
 		ifeq L16
 		getstatic java/lang/System.out java/io/PrintStream
@@ -104,10 +104,10 @@ public class if_with_strings_without_and_or {
 		ldc "bbb"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		ifgt L24
-		iconst 1 
+		iconst 1
 		goto L25
 		L24:
-		iconst 0 
+		iconst 0
 		L25:
 		ifeq L21
 		getstatic java/lang/System.out java/io/PrintStream
@@ -130,10 +130,10 @@ public class if_with_strings_without_and_or {
 		ldc "aaa"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		ifgt L29
-		iconst 1 
+		iconst 1
 		goto L30
 		L29:
-		iconst 0 
+		iconst 0
 		L30:
 		ifeq L26
 		getstatic java/lang/System.out java/io/PrintStream
@@ -156,10 +156,10 @@ public class if_with_strings_without_and_or {
 		ldc "aaa"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		iflt L34
-		iconst 1 
+		iconst 1
 		goto L35
 		L34:
-		iconst 0 
+		iconst 0
 		L35:
 		ifeq L31
 		getstatic java/lang/System.out java/io/PrintStream
@@ -182,10 +182,10 @@ public class if_with_strings_without_and_or {
 		ldc "bbb"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		iflt L39
-		iconst 1 
+		iconst 1
 		goto L40
 		L39:
-		iconst 0 
+		iconst 0
 		L40:
 		ifeq L36
 		getstatic java/lang/System.out java/io/PrintStream
@@ -208,10 +208,10 @@ public class if_with_strings_without_and_or {
 		ldc "aaa"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		iflt L44
-		iconst 1 
+		iconst 1
 		goto L45
 		L44:
-		iconst 0 
+		iconst 0
 		L45:
 		ifeq L41
 		getstatic java/lang/System.out java/io/PrintStream
@@ -234,10 +234,10 @@ public class if_with_strings_without_and_or {
 		ldc "bbb"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		ifgt L49
-		iconst 1 
+		iconst 1
 		goto L50
 		L49:
-		iconst 0 
+		iconst 0
 		L50:
 		ifeq L46
 		getstatic java/lang/System.out java/io/PrintStream
@@ -260,10 +260,10 @@ public class if_with_strings_without_and_or {
 		ldc "aaa"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		ifgt L54
-		iconst 1 
+		iconst 1
 		goto L55
 		L54:
-		iconst 0 
+		iconst 0
 		L55:
 		ifeq L51
 		getstatic java/lang/System.out java/io/PrintStream
@@ -286,10 +286,10 @@ public class if_with_strings_without_and_or {
 		ldc "aaa"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		ifgt L59
-		iconst 1 
+		iconst 1
 		goto L60
 		L59:
-		iconst 0 
+		iconst 0
 		L60:
 		ifeq L56
 		getstatic java/lang/System.out java/io/PrintStream
@@ -312,10 +312,10 @@ public class if_with_strings_without_and_or {
 		ldc "bbb"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		ifne L64
-		iconst 1 
+		iconst 1
 		goto L65
 		L64:
-		iconst 0 
+		iconst 0
 		L65:
 		ifeq L61
 		getstatic java/lang/System.out java/io/PrintStream
@@ -338,10 +338,10 @@ public class if_with_strings_without_and_or {
 		ldc "bbb"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		ifne L69
-		iconst 1 
+		iconst 1
 		goto L70
 		L69:
-		iconst 0 
+		iconst 0
 		L70:
 		ifeq L66
 		getstatic java/lang/System.out java/io/PrintStream
@@ -364,10 +364,10 @@ public class if_with_strings_without_and_or {
 		ldc "bbb"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		ifeq L74
-		iconst 1 
+		iconst 1
 		goto L75
 		L74:
-		iconst 0 
+		iconst 0
 		L75:
 		ifeq L71
 		getstatic java/lang/System.out java/io/PrintStream
@@ -390,10 +390,10 @@ public class if_with_strings_without_and_or {
 		ldc "aaa"
 		invokevirtual java/lang/String.compareTo(java/lang/String)I
 		ifeq L79
-		iconst 1 
+		iconst 1
 		goto L80
 		L79:
-		iconst 0 
+		iconst 0
 		L80:
 		ifeq L76
 		getstatic java/lang/System.out java/io/PrintStream

--- a/tests/valid_pascal_programs/if_without_else.jasm
+++ b/tests/valid_pascal_programs/if_without_else.jasm
@@ -4,10 +4,10 @@ public class if_without_else {
 		sipush 111
 		sipush 222
 		if_icmple L4
-		iconst 1 
+		iconst 1
 		goto L5
 		L4:
-		iconst 0 
+		iconst 0
 		L5:
 		ifeq L1
 		getstatic java/lang/System.out java/io/PrintStream

--- a/tests/valid_pascal_programs/local_vars.jasm
+++ b/tests/valid_pascal_programs/local_vars.jasm
@@ -3,18 +3,18 @@ public class local_vars {
 	static addvalues(I, I)I {
 		iload 0
 		iload 1
-		iadd 
+		iadd
 		istore 2
 		iload 2
 		istore 100
 		iload 100
-		ireturn 
+		ireturn
 	}
 	public static main([java/lang/String)V {
 		getstatic java/lang/System.out java/io/PrintStream
 		sipush 2
 		sipush 4
-		invokestatic local_vars.addvalues(I, I)I 
+		invokestatic local_vars.addvalues(I, I)I
 		invokevirtual java/io/PrintStream.print(I)V
 		getstatic java/lang/System.out java/io/PrintStream
 		invokevirtual java/io/PrintStream.println()V

--- a/tests/valid_pascal_programs/mul_three_numbers.jasm
+++ b/tests/valid_pascal_programs/mul_three_numbers.jasm
@@ -4,9 +4,9 @@ public class mul_three_numbers {
 		getstatic java/lang/System.out java/io/PrintStream
 		sipush 8
 		sipush 4
-		imul 
+		imul
 		sipush 2
-		imul 
+		imul
 		invokevirtual java/io/PrintStream.print(I)V
 		getstatic java/lang/System.out java/io/PrintStream
 		invokevirtual java/io/PrintStream.println()V

--- a/tests/valid_pascal_programs/nested_fors.jasm
+++ b/tests/valid_pascal_programs/nested_fors.jasm
@@ -31,13 +31,13 @@ public class nested_fors {
 		invokevirtual java/io/PrintStream.println()V
 		getstatic nested_fors.j I
 		sipush 1
-		iadd 
+		iadd
 		putstatic nested_fors.j I
 		goto L6
 		L5:
 		getstatic nested_fors.i I
 		sipush 1
-		iadd 
+		iadd
 		putstatic nested_fors.i I
 		goto L3
 		L2:

--- a/tests/valid_pascal_programs/nested_ifs.jasm
+++ b/tests/valid_pascal_programs/nested_ifs.jasm
@@ -4,19 +4,19 @@ public class nested_ifs {
 		sipush 1
 		sipush 2
 		if_icmple L4
-		iconst 1 
+		iconst 1
 		goto L5
 		L4:
-		iconst 0 
+		iconst 0
 		L5:
 		ifeq L1
 		sipush 2
 		sipush 3
 		if_icmple L9
-		iconst 1 
+		iconst 1
 		goto L10
 		L9:
-		iconst 0 
+		iconst 0
 		L10:
 		ifeq L6
 		getstatic java/lang/System.out java/io/PrintStream
@@ -43,19 +43,19 @@ public class nested_ifs {
 		sipush 1
 		sipush 2
 		if_icmpge L14
-		iconst 1 
+		iconst 1
 		goto L15
 		L14:
-		iconst 0 
+		iconst 0
 		L15:
 		ifeq L11
 		sipush 2
 		sipush 3
 		if_icmpge L19
-		iconst 1 
+		iconst 1
 		goto L20
 		L19:
-		iconst 0 
+		iconst 0
 		L20:
 		ifeq L16
 		getstatic java/lang/System.out java/io/PrintStream
@@ -82,19 +82,19 @@ public class nested_ifs {
 		sipush 1
 		sipush 2
 		if_icmpge L24
-		iconst 1 
+		iconst 1
 		goto L25
 		L24:
-		iconst 0 
+		iconst 0
 		L25:
 		ifeq L21
 		sipush 2
 		sipush 3
 		if_icmple L29
-		iconst 1 
+		iconst 1
 		goto L30
 		L29:
-		iconst 0 
+		iconst 0
 		L30:
 		ifeq L26
 		getstatic java/lang/System.out java/io/PrintStream
@@ -121,19 +121,19 @@ public class nested_ifs {
 		sipush 1
 		sipush 2
 		if_icmple L34
-		iconst 1 
+		iconst 1
 		goto L35
 		L34:
-		iconst 0 
+		iconst 0
 		L35:
 		ifeq L31
 		sipush 2
 		sipush 3
 		if_icmple L39
-		iconst 1 
+		iconst 1
 		goto L40
 		L39:
-		iconst 0 
+		iconst 0
 		L40:
 		ifeq L36
 		getstatic java/lang/System.out java/io/PrintStream
@@ -154,19 +154,19 @@ public class nested_ifs {
 		sipush 1
 		sipush 2
 		if_icmpge L44
-		iconst 1 
+		iconst 1
 		goto L45
 		L44:
-		iconst 0 
+		iconst 0
 		L45:
 		ifeq L41
 		sipush 2
 		sipush 3
 		if_icmpge L49
-		iconst 1 
+		iconst 1
 		goto L50
 		L49:
-		iconst 0 
+		iconst 0
 		L50:
 		ifeq L46
 		getstatic java/lang/System.out java/io/PrintStream

--- a/tests/valid_pascal_programs/nested_repeats.jasm
+++ b/tests/valid_pascal_programs/nested_repeats.jasm
@@ -30,10 +30,10 @@ public class nested_repeats {
 		getstatic nested_repeats.j I
 		sipush 5
 		if_icmplt L7
-		iconst 1 
+		iconst 1
 		goto L8
 		L7:
-		iconst 0 
+		iconst 0
 		L8:
 		ifeq L6
 		getstatic nested_repeats.i I
@@ -43,10 +43,10 @@ public class nested_repeats {
 		getstatic nested_repeats.i I
 		sipush 5
 		if_icmplt L9
-		iconst 1 
+		iconst 1
 		goto L10
 		L9:
-		iconst 0 
+		iconst 0
 		L10:
 		ifeq L3
 		return

--- a/tests/valid_pascal_programs/nested_repeats.jasm
+++ b/tests/valid_pascal_programs/nested_repeats.jasm
@@ -25,7 +25,7 @@ public class nested_repeats {
 		invokevirtual java/io/PrintStream.println()V
 		getstatic nested_repeats.j I
 		sipush 1
-		iadd 
+		iadd
 		putstatic nested_repeats.j I
 		getstatic nested_repeats.j I
 		sipush 5
@@ -38,7 +38,7 @@ public class nested_repeats {
 		ifeq L6
 		getstatic nested_repeats.i I
 		sipush 1
-		iadd 
+		iadd
 		putstatic nested_repeats.i I
 		getstatic nested_repeats.i I
 		sipush 5

--- a/tests/valid_pascal_programs/nested_whiles.jasm
+++ b/tests/valid_pascal_programs/nested_whiles.jasm
@@ -43,13 +43,13 @@ public class nested_whiles {
 		invokevirtual java/io/PrintStream.println()V
 		getstatic nested_whiles.j I
 		sipush 1
-		iadd 
+		iadd
 		putstatic nested_whiles.j I
 		goto L8
 		L7:
 		getstatic nested_whiles.i I
 		sipush 1
-		iadd 
+		iadd
 		putstatic nested_whiles.i I
 		goto L3
 		L2:

--- a/tests/valid_pascal_programs/nested_whiles.jasm
+++ b/tests/valid_pascal_programs/nested_whiles.jasm
@@ -9,10 +9,10 @@ public class nested_whiles {
 		getstatic nested_whiles.i I
 		sipush 4
 		if_icmpgt L4
-		iconst 1 
+		iconst 1
 		goto L5
 		L4:
-		iconst 0 
+		iconst 0
 		L5:
 		ifeq L2
 		sipush 1
@@ -21,10 +21,10 @@ public class nested_whiles {
 		getstatic nested_whiles.j I
 		sipush 4
 		if_icmpgt L9
-		iconst 1 
+		iconst 1
 		goto L10
 		L9:
-		iconst 0 
+		iconst 0
 		L10:
 		ifeq L7
 		getstatic java/lang/System.out java/io/PrintStream

--- a/tests/valid_pascal_programs/operator_precedence.jasm
+++ b/tests/valid_pascal_programs/operator_precedence.jasm
@@ -7,9 +7,9 @@ public class operator_precedence {
 		getstatic java/lang/System.out java/io/PrintStream
 		sipush 8
 		sipush 4
-		imul 
+		imul
 		sipush 2
-		isub 
+		isub
 		invokevirtual java/io/PrintStream.print(I)V
 		getstatic java/lang/System.out java/io/PrintStream
 		invokevirtual java/io/PrintStream.println()V
@@ -20,8 +20,8 @@ public class operator_precedence {
 		sipush 10
 		sipush 4
 		sipush 2
-		imul 
-		isub 
+		imul
+		isub
 		invokevirtual java/io/PrintStream.print(I)V
 		getstatic java/lang/System.out java/io/PrintStream
 		invokevirtual java/io/PrintStream.println()V
@@ -32,8 +32,8 @@ public class operator_precedence {
 		sipush 10
 		sipush 4
 		sipush 2
-		imul 
-		isub 
+		imul
+		isub
 		invokevirtual java/io/PrintStream.print(I)V
 		getstatic java/lang/System.out java/io/PrintStream
 		invokevirtual java/io/PrintStream.println()V
@@ -43,9 +43,9 @@ public class operator_precedence {
 		getstatic java/lang/System.out java/io/PrintStream
 		sipush 10
 		sipush 4
-		isub 
+		isub
 		sipush 2
-		imul 
+		imul
 		invokevirtual java/io/PrintStream.print(I)V
 		getstatic java/lang/System.out java/io/PrintStream
 		invokevirtual java/io/PrintStream.println()V
@@ -55,11 +55,11 @@ public class operator_precedence {
 		getstatic java/lang/System.out java/io/PrintStream
 		sipush 10
 		sipush 2
-		idiv 
+		idiv
 		sipush 2
-		imul 
+		imul
 		sipush 1
-		isub 
+		isub
 		invokevirtual java/io/PrintStream.print(I)V
 		getstatic java/lang/System.out java/io/PrintStream
 		invokevirtual java/io/PrintStream.println()V
@@ -69,11 +69,11 @@ public class operator_precedence {
 		getstatic java/lang/System.out java/io/PrintStream
 		sipush 10
 		sipush 2
-		idiv 
+		idiv
 		sipush 2
-		imul 
+		imul
 		sipush 1
-		isub 
+		isub
 		invokevirtual java/io/PrintStream.print(I)V
 		getstatic java/lang/System.out java/io/PrintStream
 		invokevirtual java/io/PrintStream.println()V

--- a/tests/valid_pascal_programs/operator_precedence_one_test.jasm
+++ b/tests/valid_pascal_programs/operator_precedence_one_test.jasm
@@ -5,15 +5,15 @@ public class operator_precedence_one_test {
 		sipush 10
 		sipush 4
 		sipush 2
-		imul 
-		isub 
+		imul
+		isub
 		invokevirtual java/io/PrintStream.print(I)V
 		getstatic java/lang/System.out java/io/PrintStream
 		sipush 10
 		sipush 4
-		isub 
+		isub
 		sipush 2
-		imul 
+		imul
 		invokevirtual java/io/PrintStream.print(I)V
 		return
 	}

--- a/tests/valid_pascal_programs/procedure_call_add_numbers.jasm
+++ b/tests/valid_pascal_programs/procedure_call_add_numbers.jasm
@@ -4,7 +4,7 @@ public class procedure_call_add_numbers {
 		getstatic java/lang/System.out java/io/PrintStream
 		iload 0
 		iload 1
-		iadd 
+		iadd
 		invokevirtual java/io/PrintStream.print(I)V
 		getstatic java/lang/System.out java/io/PrintStream
 		invokevirtual java/io/PrintStream.println()V
@@ -13,7 +13,7 @@ public class procedure_call_add_numbers {
 	public static main([java/lang/String)V {
 		sipush 4
 		sipush 6
-		invokestatic procedure_call_add_numbers.add(I, I)V 
+		invokestatic procedure_call_add_numbers.add(I, I)V
 		return
 	}
 }

--- a/tests/valid_pascal_programs/procedure_call_with_mixed_params.jasm
+++ b/tests/valid_pascal_programs/procedure_call_with_mixed_params.jasm
@@ -7,7 +7,7 @@ public class procedure_call_with_mixed_params {
 		getstatic java/lang/System.out java/io/PrintStream
 		iload 1
 		iload 2
-		iadd 
+		iadd
 		invokevirtual java/io/PrintStream.print(I)V
 		getstatic java/lang/System.out java/io/PrintStream
 		invokevirtual java/io/PrintStream.println()V
@@ -17,7 +17,7 @@ public class procedure_call_with_mixed_params {
 		ldc "2+4="
 		sipush 2
 		sipush 4
-		invokestatic procedure_call_with_mixed_params.addvalues(java/lang/String, I, I)V 
+		invokestatic procedure_call_with_mixed_params.addvalues(java/lang/String, I, I)V
 		return
 	}
 }

--- a/tests/valid_pascal_programs/procedure_call_with_one_param.jasm
+++ b/tests/valid_pascal_programs/procedure_call_with_one_param.jasm
@@ -5,13 +5,13 @@ public class procedure_call_with_one_param {
 		ldc "Hello "
 		aload 0
 		invokedynamic makeConcatWithConstants(java/lang/String, java/lang/String)java/lang/String {
-			invokestatic java/lang/invoke/StringConcatFactory.makeConcatWithConstants(java/lang/invoke/MethodHandles$Lookup, java/lang/String, java/lang/invoke/MethodType, java/lang/String, [java/lang/Object)java/lang/invoke/CallSite 
-			[""] 
+			invokestatic java/lang/invoke/StringConcatFactory.makeConcatWithConstants(java/lang/invoke/MethodHandles$Lookup, java/lang/String, java/lang/invoke/MethodType, java/lang/String, [java/lang/Object)java/lang/invoke/CallSite
+			[""]
 		}
 		ldc "!"
 		invokedynamic makeConcatWithConstants(java/lang/String, java/lang/String)java/lang/String {
-			invokestatic java/lang/invoke/StringConcatFactory.makeConcatWithConstants(java/lang/invoke/MethodHandles$Lookup, java/lang/String, java/lang/invoke/MethodType, java/lang/String, [java/lang/Object)java/lang/invoke/CallSite 
-			[""] 
+			invokestatic java/lang/invoke/StringConcatFactory.makeConcatWithConstants(java/lang/invoke/MethodHandles$Lookup, java/lang/String, java/lang/invoke/MethodType, java/lang/String, [java/lang/Object)java/lang/invoke/CallSite
+			[""]
 		}
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		getstatic java/lang/System.out java/io/PrintStream
@@ -25,7 +25,7 @@ public class procedure_call_with_one_param {
 		getstatic java/lang/System.out java/io/PrintStream
 		invokevirtual java/io/PrintStream.println()V
 		ldc "Alex"
-		invokestatic procedure_call_with_one_param.myprocedure(java/lang/String)V 
+		invokestatic procedure_call_with_one_param.myprocedure(java/lang/String)V
 		return
 	}
 }

--- a/tests/valid_pascal_programs/procedure_call_with_two_params.jasm
+++ b/tests/valid_pascal_programs/procedure_call_with_two_params.jasm
@@ -5,18 +5,18 @@ public class procedure_call_with_two_params {
 		aload 0
 		ldc " "
 		invokedynamic makeConcatWithConstants(java/lang/String, java/lang/String)java/lang/String {
-			invokestatic java/lang/invoke/StringConcatFactory.makeConcatWithConstants(java/lang/invoke/MethodHandles$Lookup, java/lang/String, java/lang/invoke/MethodType, java/lang/String, [java/lang/Object)java/lang/invoke/CallSite 
-			[""] 
+			invokestatic java/lang/invoke/StringConcatFactory.makeConcatWithConstants(java/lang/invoke/MethodHandles$Lookup, java/lang/String, java/lang/invoke/MethodType, java/lang/String, [java/lang/Object)java/lang/invoke/CallSite
+			[""]
 		}
 		aload 1
 		invokedynamic makeConcatWithConstants(java/lang/String, java/lang/String)java/lang/String {
-			invokestatic java/lang/invoke/StringConcatFactory.makeConcatWithConstants(java/lang/invoke/MethodHandles$Lookup, java/lang/String, java/lang/invoke/MethodType, java/lang/String, [java/lang/Object)java/lang/invoke/CallSite 
-			[""] 
+			invokestatic java/lang/invoke/StringConcatFactory.makeConcatWithConstants(java/lang/invoke/MethodHandles$Lookup, java/lang/String, java/lang/invoke/MethodType, java/lang/String, [java/lang/Object)java/lang/invoke/CallSite
+			[""]
 		}
 		ldc "!"
 		invokedynamic makeConcatWithConstants(java/lang/String, java/lang/String)java/lang/String {
-			invokestatic java/lang/invoke/StringConcatFactory.makeConcatWithConstants(java/lang/invoke/MethodHandles$Lookup, java/lang/String, java/lang/invoke/MethodType, java/lang/String, [java/lang/Object)java/lang/invoke/CallSite 
-			[""] 
+			invokestatic java/lang/invoke/StringConcatFactory.makeConcatWithConstants(java/lang/invoke/MethodHandles$Lookup, java/lang/String, java/lang/invoke/MethodType, java/lang/String, [java/lang/Object)java/lang/invoke/CallSite
+			[""]
 		}
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		getstatic java/lang/System.out java/io/PrintStream
@@ -31,7 +31,7 @@ public class procedure_call_with_two_params {
 		invokevirtual java/io/PrintStream.println()V
 		ldc "Hello"
 		ldc "Alex"
-		invokestatic procedure_call_with_two_params.myprocedure(java/lang/String, java/lang/String)V 
+		invokestatic procedure_call_with_two_params.myprocedure(java/lang/String, java/lang/String)V
 		return
 	}
 }

--- a/tests/valid_pascal_programs/procedure_call_wo_params.jasm
+++ b/tests/valid_pascal_programs/procedure_call_wo_params.jasm
@@ -14,7 +14,7 @@ public class procedure_call_wo_params {
 		invokevirtual java/io/PrintStream.print(java/lang/String)V
 		getstatic java/lang/System.out java/io/PrintStream
 		invokevirtual java/io/PrintStream.println()V
-		invokestatic procedure_call_wo_params.myprocedure()V 
+		invokestatic procedure_call_wo_params.myprocedure()V
 		return
 	}
 }

--- a/tests/valid_pascal_programs/repeat.jasm
+++ b/tests/valid_pascal_programs/repeat.jasm
@@ -15,7 +15,7 @@ public class repeat {
 		invokevirtual java/io/PrintStream.println()V
 		getstatic repeat.i I
 		sipush 1
-		iadd 
+		iadd
 		putstatic repeat.i I
 		getstatic repeat.i I
 		sipush 20

--- a/tests/valid_pascal_programs/repeat.jasm
+++ b/tests/valid_pascal_programs/repeat.jasm
@@ -20,10 +20,10 @@ public class repeat {
 		getstatic repeat.i I
 		sipush 20
 		if_icmpne L4
-		iconst 1 
+		iconst 1
 		goto L5
 		L4:
-		iconst 0 
+		iconst 0
 		L5:
 		ifeq L3
 		return

--- a/tests/valid_pascal_programs/sub_three_numbers.jasm
+++ b/tests/valid_pascal_programs/sub_three_numbers.jasm
@@ -4,9 +4,9 @@ public class sub_three_numbers {
 		getstatic java/lang/System.out java/io/PrintStream
 		sipush 8
 		sipush 4
-		isub 
+		isub
 		sipush 2
-		isub 
+		isub
 		invokevirtual java/io/PrintStream.print(I)V
 		getstatic java/lang/System.out java/io/PrintStream
 		invokevirtual java/io/PrintStream.println()V

--- a/tests/valid_pascal_programs/sub_two_numbers.jasm
+++ b/tests/valid_pascal_programs/sub_two_numbers.jasm
@@ -4,7 +4,7 @@ public class sub_two_numbers {
 		getstatic java/lang/System.out java/io/PrintStream
 		sipush 4
 		sipush 3
-		isub 
+		isub
 		invokevirtual java/io/PrintStream.print(I)V
 		getstatic java/lang/System.out java/io/PrintStream
 		invokevirtual java/io/PrintStream.println()V

--- a/tests/valid_pascal_programs/while.jasm
+++ b/tests/valid_pascal_programs/while.jasm
@@ -24,7 +24,7 @@ public class while {
 		invokevirtual java/io/PrintStream.println()V
 		getstatic while.i I
 		sipush 1
-		iadd 
+		iadd
 		putstatic while.i I
 		goto L3
 		L2:
@@ -50,7 +50,7 @@ public class while {
 		invokevirtual java/io/PrintStream.println()V
 		getstatic while.i I
 		sipush 1
-		iadd 
+		iadd
 		putstatic while.i I
 		goto L8
 		L7:

--- a/tests/valid_pascal_programs/while.jasm
+++ b/tests/valid_pascal_programs/while.jasm
@@ -8,10 +8,10 @@ public class while {
 		getstatic while.i I
 		sipush 20
 		if_icmpge L4
-		iconst 1 
+		iconst 1
 		goto L5
 		L4:
-		iconst 0 
+		iconst 0
 		L5:
 		ifeq L2
 		getstatic java/lang/System.out java/io/PrintStream
@@ -34,10 +34,10 @@ public class while {
 		getstatic while.i I
 		sipush 10
 		if_icmpgt L9
-		iconst 1 
+		iconst 1
 		goto L10
 		L9:
-		iconst 0 
+		iconst 0
 		L10:
 		ifeq L7
 		getstatic java/lang/System.out java/io/PrintStream

--- a/tests/valid_pascal_programs/while_example.jasm
+++ b/tests/valid_pascal_programs/while_example.jasm
@@ -24,7 +24,7 @@ public class while_example {
 		invokevirtual java/io/PrintStream.println()V
 		getstatic while_example.i I
 		sipush 1
-		iadd 
+		iadd
 		putstatic while_example.i I
 		goto L3
 		L2:

--- a/tests/valid_pascal_programs/while_example.jasm
+++ b/tests/valid_pascal_programs/while_example.jasm
@@ -8,10 +8,10 @@ public class while_example {
 		getstatic while_example.i I
 		sipush 20
 		if_icmpge L4
-		iconst 1 
+		iconst 1
 		goto L5
 		L4:
-		iconst 0 
+		iconst 0
 		L5:
 		ifeq L2
 		getstatic java/lang/System.out java/io/PrintStream


### PR DESCRIPTION
This PR includes changes to the `codegen/jasm.go` file, focusing on improving the consistency and cleanliness of the Java Assembly code generated.

Code consistency improvements:

* [`func (j *JASM) addPushTrueOpcode()`](diffhunk://#diff-7e6ac7e2ef73be543293dd05fda81f7638f1086b096a1c0aeb2f7d2005367cbaL554-R558): Modified to use separate arguments for the opcode and its value. (`codegen/jasm.go`, [codegen/jasm.goL554-R558](diffhunk://#diff-7e6ac7e2ef73be543293dd05fda81f7638f1086b096a1c0aeb2f7d2005367cbaL554-R558))
* [`func (j *JASM) addPushFalseOpcode()`](diffhunk://#diff-7e6ac7e2ef73be543293dd05fda81f7638f1086b096a1c0aeb2f7d2005367cbaL554-R558): Modified to use separate arguments for the opcode and its value. (`codegen/jasm.go`, [codegen/jasm.goL554-R558](diffhunk://#diff-7e6ac7e2ef73be543293dd05fda81f7638f1086b096a1c0aeb2f7d2005367cbaL554-R558))

Code cleanliness improvement:

* [`func (j *JASM) addLine(line string)`](diffhunk://#diff-7e6ac7e2ef73be543293dd05fda81f7638f1086b096a1c0aeb2f7d2005367cbaR662): Added a line to trim whitespace from the input string before adding it to the code. (`codegen/jasm.go`, [codegen/jasm.goR662](diffhunk://#diff-7e6ac7e2ef73be543293dd05fda81f7638f1086b096a1c0aeb2f7d2005367cbaR662))